### PR TITLE
TRANSFER-650: Add append-only mark for kinesis source

### DIFF
--- a/transfer_manager/go/pkg/providers/kinesis/model_source.go
+++ b/transfer_manager/go/pkg/providers/kinesis/model_source.go
@@ -3,6 +3,7 @@ package kinesis
 import (
 	"github.com/doublecloud/transfer/transfer_manager/go/pkg/abstract"
 	"github.com/doublecloud/transfer/transfer_manager/go/pkg/abstract/model"
+	"github.com/doublecloud/transfer/transfer_manager/go/pkg/parsers"
 )
 
 var (
@@ -34,3 +35,15 @@ func (k *KinesisSource) WithDefaults() {
 }
 
 func (k *KinesisSource) IsSource() {}
+
+func (s *KinesisSource) IsAppendOnly() bool {
+	if s.ParserConfig == nil {
+		return true
+	} else {
+		parserConfigStruct, _ := parsers.ParserConfigMapToStruct(s.ParserConfig)
+		if parserConfigStruct == nil {
+			return true
+		}
+		return parserConfigStruct.IsAppendOnly()
+	}
+}


### PR DESCRIPTION
It by default updateable, this creates not a pefect DDL for target clickhouse