### PR TITLE
Remove runtime from tests

### DIFF
--- a/transfer_manager/go/tests/e2e/pg2yt/snapshot_incremental/check_db_test.go
+++ b/transfer_manager/go/tests/e2e/pg2yt/snapshot_incremental/check_db_test.go
@@ -81,7 +81,6 @@ func Snapshot(t *testing.T) {
 	Source.PreSteps.Constraint = true
 	transfer := helpers.MakeTransferForIncrementalSnapshot(helpers.TransferID, &Source, Target, abstract.TransferTypeSnapshotOnly,
 		"public", "__test", cursorField, cursorValue, 15)
-	transfer.Runtime = new(abstract.YtRuntime)
 
 	fakeClient := coordinator.NewStatefulFakeClient()
 

--- a/transfer_manager/go/tests/e2e/pg2yt/snapshot_incremental_sharded/check_db_test.go
+++ b/transfer_manager/go/tests/e2e/pg2yt/snapshot_incremental_sharded/check_db_test.go
@@ -80,7 +80,6 @@ func Snapshot(t *testing.T) {
 	Source.PreSteps.Constraint = true
 	transfer := helpers.MakeTransferForIncrementalSnapshot(helpers.TransferID, &Source, Target, abstract.TransferTypeSnapshotOnly,
 		"public", "__test", "id", "", 15)
-	transfer.Runtime = new(abstract.YtRuntime)
 
 	fakeClient := coordinator.NewStatefulFakeClient()
 


### PR DESCRIPTION
We have not YT-runtime in open-source version and don't need it in e2e tests