### PR TITLE
Fix kinesis test failure

### DIFF
--- a/tests/e2e/kinesis2ch/replication/check_db_test.go
+++ b/tests/e2e/kinesis2ch/replication/check_db_test.go
@@ -108,7 +108,3 @@ func TestReplication(t *testing.T) {
 		User:       target.User,
 	})
 }
-
-func TestSnapshot(t *testing.T) {
-	TestReplication(t)
-}


### PR DESCRIPTION
Replication tests was running twice, once as test replication and another time as test snapshot, despite snapshot is not supported by kinesis.