### PR TITLE
Add env-var substitution for params

### DIFF
--- a/cmd/trcli/config/config.go
+++ b/cmd/trcli/config/config.go
@@ -64,9 +64,9 @@ func ParseTransferYaml(rawData []byte) (*TransferYamlView, error) {
 		return nil, err
 	}
 	for _, v := range os.Environ() {
-		env := os.Getenv(v)
-		transfer.Src.Params = strings.ReplaceAll(transfer.Src.Params, fmt.Sprintf("${%v}", v), env)
-		transfer.Dst.Params = strings.ReplaceAll(transfer.Dst.Params, fmt.Sprintf("${%v}", v), env)
+		pair := strings.SplitN(v, "=", 2)
+		transfer.Src.Params = strings.ReplaceAll(transfer.Src.Params, fmt.Sprintf("${%v}", pair[0]), pair[1])
+		transfer.Dst.Params = strings.ReplaceAll(transfer.Dst.Params, fmt.Sprintf("${%v}", pair[0]), pair[1])
 	}
 	return &transfer, nil
 }

--- a/cmd/trcli/config/config.go
+++ b/cmd/trcli/config/config.go
@@ -2,12 +2,14 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+
 	"github.com/doublecloud/transfer/library/go/core/xerrors"
 	"github.com/doublecloud/transfer/pkg/abstract"
 	"github.com/doublecloud/transfer/pkg/abstract/model"
-	"gopkg.in/yaml.v2"
-	"os"
-	"strings"
 )
 
 func TransferFromYaml(params *string) (*model.Transfer, error) {

--- a/cmd/trcli/config/config.go
+++ b/cmd/trcli/config/config.go
@@ -1,12 +1,13 @@
 package config
 
 import (
-	"os"
-
+	"fmt"
 	"github.com/doublecloud/transfer/library/go/core/xerrors"
 	"github.com/doublecloud/transfer/pkg/abstract"
 	"github.com/doublecloud/transfer/pkg/abstract/model"
 	"gopkg.in/yaml.v2"
+	"os"
+	"strings"
 )
 
 func TransferFromYaml(params *string) (*model.Transfer, error) {
@@ -59,6 +60,11 @@ func ParseTransferYaml(rawData []byte) (*TransferYamlView, error) {
 	var transfer TransferYamlView
 	if err := yaml.Unmarshal(rawData, &transfer); err != nil {
 		return nil, err
+	}
+	for _, v := range os.Environ() {
+		env := os.Getenv(v)
+		transfer.Src.Params = strings.ReplaceAll(transfer.Src.Params, fmt.Sprintf("${%v}", v), env)
+		transfer.Dst.Params = strings.ReplaceAll(transfer.Dst.Params, fmt.Sprintf("${%v}", v), env)
 	}
 	return &transfer, nil
 }

--- a/cmd/trcli/config/config_test.go
+++ b/cmd/trcli/config/config_test.go
@@ -1,15 +1,14 @@
 package config
 
 import (
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseTransferYaml_WithEnvSubstitution(t *testing.T) {
-
 	require.NoError(t, os.Setenv("FOO", "secret1"))
 	require.NoError(t, os.Setenv("BAR", "secret2"))
 	defer os.Unsetenv("FOO")

--- a/cmd/trcli/config/config_test.go
+++ b/cmd/trcli/config/config_test.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTransferYaml_WithEnvSubstitution(t *testing.T) {
+
+	require.NoError(t, os.Setenv("FOO", "secret1"))
+	require.NoError(t, os.Setenv("BAR", "secret2"))
+	defer os.Unsetenv("FOO")
+	defer os.Unsetenv("BAR")
+
+	transfer, err := ParseTransferYaml([]byte(`
+src:
+  type: src_type
+  params: |
+    {"Password": "${FOO}"}
+dst:
+  type: dst_type
+  params: |
+    {"Password": "${BAR}"}
+`))
+	require.NoError(t, err)
+
+	assert.Equal(t, "{\"Password\": \"secret1\"}\n", transfer.Src.Params)
+	assert.Equal(t, "{\"Password\": \"secret2\"}\n", transfer.Dst.Params)
+}


### PR DESCRIPTION
Add ENV-vars for src and dst params, user now may specify:

export FOO=secret

transfer.yaml:

```
dst:
  type: ch
  params: |
    {"Password": "${FOO}"}
```

After load this transfer yaml would be:

```
dst:
  type: ch
  params: |
    {"Password": "secret"}
```

resolves: #67 