### PR TITLE
Specify lower clickhouse ram usage

### DIFF
--- a/tests/tcrecipes/clickhouse/clickhouse.go
+++ b/tests/tcrecipes/clickhouse/clickhouse.go
@@ -173,6 +173,7 @@ func WithUsername(user string) testcontainers.CustomizeRequestOption {
 func WithZookeeper(container *ZookeeperContainer) testcontainers.CustomizeRequestOption {
 	return WithConfigData(fmt.Sprintf(`<?xml version="1.0"?>
 	<clickhouse>
+		<max_server_memory_usage>2147483648</max_server_memory_usage
 		<logger>
 			<level>debug</level>
 			<console>true</console>


### PR DESCRIPTION
In test-containers we don't need more than 2 gb-s, by default it try to it 15gb.