### PR TITLE
Describe transformer command

### DIFF
--- a/cmd/trcli/config/config.go
+++ b/cmd/trcli/config/config.go
@@ -50,9 +50,12 @@ func ParseTransfer(yaml []byte) (*model.Transfer, error) {
 	transfer := transfer(source, target, tr)
 
 	transfer.FillDependentFields()
-	if tr.Transformation != "" {
-		if err := transfer.TransformationFromJSON(tr.Transformation); err != nil {
-			return nil, xerrors.Errorf("unable to load transformation: %w", err)
+	if len(tr.Transformation.Transformers) > 0 {
+		transfer.Transformation = &model.Transformation{
+			Transformers:      &tr.Transformation,
+			ExtraTransformers: nil,
+			Executor:          nil,
+			RuntimeJobIndex:   0,
 		}
 	}
 	return transfer, nil

--- a/cmd/trcli/config/model.go
+++ b/cmd/trcli/config/model.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/doublecloud/transfer/pkg/transformer"
 	"time"
 
 	"github.com/doublecloud/transfer/pkg/abstract"
@@ -36,7 +37,7 @@ type TransferYamlView struct {
 	Src               Endpoint
 	Dst               Endpoint
 	RegularSnapshot   *abstract.RegularSnapshot `yaml:"regular_snapshot"`
-	Transformation    string                    `yaml:"transformation"`
+	Transformation    transformer.Transformers  `yaml:"transformation"`
 	DataObjects       *model.DataObjects        `yaml:"data_objects"`
 	TypeSystemVersion int                       `yaml:"type_system_version"`
 }

--- a/cmd/trcli/config/model.go
+++ b/cmd/trcli/config/model.go
@@ -1,11 +1,11 @@
 package config
 
 import (
-	"github.com/doublecloud/transfer/pkg/transformer"
 	"time"
 
 	"github.com/doublecloud/transfer/pkg/abstract"
 	"github.com/doublecloud/transfer/pkg/abstract/model"
+	"github.com/doublecloud/transfer/pkg/transformer"
 )
 
 type Endpoint struct {

--- a/pkg/abstract/model/endpoint.go
+++ b/pkg/abstract/model/endpoint.go
@@ -21,7 +21,6 @@ type Source interface {
 }
 
 type Describable interface {
-	EndpointParams
 	Describe() Doc
 }
 

--- a/pkg/transformer/registry.go
+++ b/pkg/transformer/registry.go
@@ -14,6 +14,7 @@ type TransformerFactory func(protoConfig any, lgr log.Logger, runtime abstract.T
 
 var (
 	knownTransformer = map[abstract.TransformerType]TransformerFactory{}
+	knownConfigs     = map[abstract.TransformerType]func() Config{}
 )
 
 func KnownTransformerNames() []string {
@@ -39,6 +40,18 @@ func Register[TConfig Config](typ abstract.TransformerType, f func(cfg TConfig, 
 		}
 		return f(t, lgr, runtime)
 	}
+	knownConfigs[typ] = func() Config {
+		var t TConfig
+		return t
+	}
+}
+
+func NewConfig(typ abstract.TransformerType) (Config, error) {
+	fac, ok := knownConfigs[typ]
+	if !ok {
+		return nil, xerrors.Errorf("not supported transformer %s, known: %v", typ, util.MapKeysInOrder(knownTransformer))
+	}
+	return fac(), nil
 }
 
 func New(typ abstract.TransformerType, cfg Config, lgr log.Logger, rt abstract.TransformationRuntimeOpts) (abstract.Transformer, error) {

--- a/pkg/transformer/registry/clickhouse/clickhouse_local.go
+++ b/pkg/transformer/registry/clickhouse/clickhouse_local.go
@@ -2,6 +2,7 @@ package clickhouse
 
 import (
 	"bytes"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/doublecloud/transfer/library/go/core/xerrors"
 	"github.com/doublecloud/transfer/pkg/abstract"
+	"github.com/doublecloud/transfer/pkg/abstract/model"
 	"github.com/doublecloud/transfer/pkg/abstract/typesystem"
 	"github.com/doublecloud/transfer/pkg/format"
 	"github.com/doublecloud/transfer/pkg/providers/clickhouse"
@@ -50,9 +52,32 @@ func init() {
 	})
 }
 
+var (
+	//go:embed README.md
+	readme []byte
+	_      model.Describable = (*Config)(nil)
+)
+
 type Config struct {
-	Tables filter.Tables `json:"tables"`
-	Query  string        `json:"query"`
+	Tables filter.Tables `json:"tables" yaml:"tables"`
+	Query  string        `json:"query" yaml:"query,flow"`
+}
+
+func (c Config) Describe() model.Doc {
+	return model.Doc{
+		Usage: string(readme),
+		Example: `
+tables:                                                                       
+	include_tables:                                                             
+	- '"public"."included_data"'                                                
+	exclude_tables:                                                             
+	- '"public"."excluded_data"'                                                
+query: |
+	select
+		* 
+	from table
+`,
+	}
 }
 
 type ClickhouseTransformer struct {

--- a/pkg/transformer/registry/filter/filter.go
+++ b/pkg/transformer/registry/filter/filter.go
@@ -7,18 +7,18 @@ import (
 )
 
 type Tables struct {
-	IncludeTables []string `json:"includeTables"`
-	ExcludeTables []string `json:"excludeTables"`
+	IncludeTables []string `json:"includeTables" yaml:"include_tables"`
+	ExcludeTables []string `json:"excludeTables" yaml:"exclude_tables"`
 }
 
 type Columns struct {
-	IncludeColumns []string `json:"includeColumns"`
-	ExcludeColumns []string `json:"excludeColumns"`
+	IncludeColumns []string `json:"includeColumns" yaml:"include_columns"`
+	ExcludeColumns []string `json:"excludeColumns" yaml:"exclude_columns"`
 }
 
 type Filter struct {
-	IncludeRegexp []string `json:"includeRegexp"`
-	ExcludeRegexp []string `json:"excludeRegexp"`
+	IncludeRegexp []string `json:"includeRegexp" yaml:"include_regexp"`
+	ExcludeRegexp []string `json:"excludeRegexp" yaml:"exclude_regexp"`
 
 	compiledInclude []*regexp.Regexp
 	compiledExclude []*regexp.Regexp


### PR DESCRIPTION
Add new cli command: `trcli describe transformer --type sql`

This command describe how to use specific transformer + list all available transformers:

```
./binaries/main describe transformer --type sql

  ## Clickhouse transformer

  Based on Clickhouse Local
  https://clickhouse.com/docs/en/operations/utilities/clickhouse-local/

  This tool accept clickhouse SQL dialect and allow to produce SQL-like in memory
  data transformation.

  Image: diagram → https://jing.yandex-team.ru/files/tserakhau/ch_local_trans.svg

  Source table inside CH Local named as  table , clickhouse table structure mimic
  source table structure.

  Since each source change item (row) contains extra metadata we must match source
  and target data together. There for each row must have a key defined. All of
  this key should be uniq in every batch (for this we call collapse function). If
  we can't match source keys with transformed data we will mark such row as
  errored.

   Example Config

    tables:
        include_tables:
        - '"public"."included_data"'
        exclude_tables:
        - '"public"."excluded_data"'
    query: |
        select
                *
        from table
```

To make configs more user friendly query become a yaml filed, instead of json-baked string field.