### PR TITLE
Params as any, not string

### DIFF
--- a/cmd/trcli/config/config.go
+++ b/cmd/trcli/config/config.go
@@ -68,14 +68,14 @@ func ParseTransferYaml(rawData []byte) (*TransferYamlView, error) {
 	}
 	for _, v := range os.Environ() {
 		pair := strings.SplitN(v, "=", 2)
-		transfer.Src.Params = strings.ReplaceAll(transfer.Src.Params, fmt.Sprintf("${%v}", pair[0]), pair[1])
-		transfer.Dst.Params = strings.ReplaceAll(transfer.Dst.Params, fmt.Sprintf("${%v}", pair[0]), pair[1])
+		transfer.Src.Params = strings.ReplaceAll(transfer.Src.JsonParams(), fmt.Sprintf("${%v}", pair[0]), pair[1])
+		transfer.Dst.Params = strings.ReplaceAll(transfer.Dst.JsonParams(), fmt.Sprintf("${%v}", pair[0]), pair[1])
 	}
-	res, err := sig_yaml.YAMLToJSON([]byte(transfer.Src.Params))
+	res, err := sig_yaml.YAMLToJSON([]byte(transfer.Src.JsonParams()))
 	if err == nil {
 		transfer.Src.Params = string(res)
 	}
-	res, err = sig_yaml.YAMLToJSON([]byte(transfer.Dst.Params))
+	res, err = sig_yaml.YAMLToJSON([]byte(transfer.Dst.JsonParams()))
 	if err == nil {
 		transfer.Dst.Params = string(res)
 	}
@@ -103,11 +103,11 @@ func ParseTablesYaml(rawData []byte) (*UploadTables, error) {
 }
 
 func source(tr *TransferYamlView) (model.Source, error) {
-	return model.NewSource(tr.Src.Type, tr.Src.Params)
+	return model.NewSource(tr.Src.Type, tr.Src.JsonParams())
 }
 
 func target(tr *TransferYamlView) (model.Destination, error) {
-	return model.NewDestination(tr.Dst.Type, tr.Dst.Params)
+	return model.NewDestination(tr.Dst.Type, tr.Dst.JsonParams())
 }
 
 func transfer(source model.Source, target model.Destination, tr *TransferYamlView) *model.Transfer {

--- a/cmd/trcli/config/config_test.go
+++ b/cmd/trcli/config/config_test.go
@@ -30,7 +30,7 @@ dst:
 	assert.Equal(t, "{\"Password\":\"secret2\"}", transfer.Dst.Params)
 }
 
-func TestParserTransferYaml_WithYaml(t *testing.T) {
+func TestParserTransferYaml_WithRawYaml(t *testing.T) {
 	require.NoError(t, os.Setenv("FOO", "secret1"))
 	require.NoError(t, os.Setenv("BAR", "secret2"))
 	defer os.Unsetenv("FOO")
@@ -44,6 +44,28 @@ src:
 dst:
   type: dst_type
   params: |
+    Password: ${BAR}
+`))
+	require.NoError(t, err)
+
+	assert.Equal(t, "{\"Password\":\"secret1\"}", transfer.Src.Params)
+	assert.Equal(t, "{\"Password\":\"secret2\"}", transfer.Dst.Params)
+}
+
+func TestParserTransferYaml_WithYaml(t *testing.T) {
+	require.NoError(t, os.Setenv("FOO", "secret1"))
+	require.NoError(t, os.Setenv("BAR", "secret2"))
+	defer os.Unsetenv("FOO")
+	defer os.Unsetenv("BAR")
+
+	transfer, err := ParseTransferYaml([]byte(`
+src:
+  type: src_type
+  params:
+    Password: ${FOO}
+dst:
+  type: dst_type
+  params:
     Password: ${BAR}
 `))
 	require.NoError(t, err)

--- a/cmd/trcli/config/model.go
+++ b/cmd/trcli/config/model.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"gopkg.in/yaml.v2"
 	"time"
 
 	"github.com/doublecloud/transfer/pkg/abstract"
@@ -11,7 +12,19 @@ import (
 type Endpoint struct {
 	ID, Name string
 	Type     abstract.ProviderType
-	Params   string
+	Params   any
+}
+
+func (e Endpoint) JsonParams() string {
+	switch p := e.Params.(type) {
+	case []byte:
+		return string(p)
+	case string:
+		return p
+	default:
+		data, _ := yaml.Marshal(p)
+		return string(data)
+	}
 }
 
 type Runtime struct {


### PR DESCRIPTION
Having params as string make it ugly to pass configs, json or yaml encoded strings inside yaml is not highlighted in editors, to make UX slightly better allowed to pass here a proper struct. Backward compatibility is preserved.