### PR TITLE
Kafka source offset policy

### DIFF
--- a/pkg/providers/kafka/model_source.go
+++ b/pkg/providers/kafka/model_source.go
@@ -23,7 +23,17 @@ type KafkaSource struct {
 	ParserConfig        map[string]interface{}
 	IsHomo              bool // enabled kafka mirror protocol which can work only with kafka target
 	SynchronizeIsNeeded bool // true, if we need to send synchronize events on releasing partitions
+
+	OffsetPolicy OffsetPolicy // specify from what topic part start message consumption
 }
+
+type OffsetPolicy string
+
+const (
+	NoOffsetPolicy      = OffsetPolicy("") // Not specified
+	AtStartOffsetPolicy = OffsetPolicy("at_start")
+	AtEndOffsetPolicy   = OffsetPolicy("at_end")
+)
 
 var _ model.Source = (*KafkaSource)(nil)
 

--- a/pkg/providers/kafka/source.go
+++ b/pkg/providers/kafka/source.go
@@ -524,7 +524,13 @@ func newSourceWithCallbacks(cfg *KafkaSource, logger log.Logger, registry metric
 			source.partitionReleased = true
 		}),
 		kgo.ConsumeTopics(topics...),
+		kgo.ConsumeResetOffset(kgo.NewOffset()),
 	)
+	if cfg.OffsetPolicy == AtStartOffsetPolicy {
+		opts = append(opts, kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()))
+	} else if cfg.OffsetPolicy == AtEndOffsetPolicy {
+		opts = append(opts, kgo.ConsumeResetOffset(kgo.NewOffset().AtEnd()))
+	}
 
 	kfClient, err := kgo.NewClient(opts...)
 	if err != nil {

--- a/pkg/providers/kafka/source.go
+++ b/pkg/providers/kafka/source.go
@@ -524,7 +524,6 @@ func newSourceWithCallbacks(cfg *KafkaSource, logger log.Logger, registry metric
 			source.partitionReleased = true
 		}),
 		kgo.ConsumeTopics(topics...),
-		kgo.ConsumeResetOffset(kgo.NewOffset()),
 	)
 	if cfg.OffsetPolicy == AtStartOffsetPolicy {
 		opts = append(opts, kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()))

--- a/pkg/providers/kafka/source_test.go
+++ b/pkg/providers/kafka/source_test.go
@@ -197,7 +197,7 @@ func TestOffsetPolicy(t *testing.T) {
 	items, err := src.Fetch()
 	require.NoError(t, err)
 	src.Stop()
-	require.Len(t, items, 3)
+	require.True(t, len(items) >= 3) // At least 3 old items
 	abstract.Dump(items)
 
 	go func() {


### PR DESCRIPTION
Allow to specify offset policy to read topic either at start or at end of a data, this simplify initial setup and allow to crop bad data from the past.

closes #127