### PR TITLE
Skip folder from s3 listing

### DIFF
--- a/pkg/coordinator/s3coordinator/coordinator_s3.go
+++ b/pkg/coordinator/s3coordinator/coordinator_s3.go
@@ -51,6 +51,10 @@ func (c *CoordinatorS3) GetTransferState(transferID string) (map[string]*coordin
 
 	// Fetch each object and deserialize the JSON
 	for _, obj := range listResp.Contents {
+		if obj.Size == nil || *obj.Size == 0 {
+			// see: https://stackoverflow.com/questions/75620230/aws-s3-listobjectsv2-returns-folder-as-an-object
+			continue
+		}
 		key := strings.TrimPrefix(*obj.Key, prefix)
 		getInput := &s3.GetObjectInput{
 			Bucket: aws.String(c.bucket),


### PR DESCRIPTION
When list and s3 for state folders may be created as separate object with 0 size, such objects should be skipped

closes #130