### PR TITLE
Allow to specify rotational TZ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ FROM ubuntu:jammy
 
 ENV TZ=Etc/UTC
 
+ENV ROTATION_TZ=Etc/UTC
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN echo $TZ > /etc/timezone && \

--- a/pkg/abstract/model/endpoint_rotator_config.go
+++ b/pkg/abstract/model/endpoint_rotator_config.go
@@ -13,8 +13,8 @@ import (
 	"github.com/doublecloud/transfer/pkg/abstract"
 )
 
-// RotationLocal -- rotation is happened in preconfigured timezone, by default - Europe/Moscow
-var RotationLocal *time.Location
+// RotationTZ -- rotation is happened in preconfigured timezone, by default - Europe/Moscow
+var RotationTZ *time.Location
 
 func init() {
 	var err error
@@ -22,9 +22,9 @@ func init() {
 	if ttz, ok := os.LookupEnv("ROTATION_TZ"); ok {
 		tz = ttz
 	}
-	if RotationLocal, err = time.LoadLocation(tz); err != nil {
-		RotationLocal = time.Local
-		logger.Log.Errorf("Couldn't initialize %s timezone. Using '%s' instead", tz, RotationLocal.String())
+	if RotationTZ, err = time.LoadLocation(tz); err != nil {
+		RotationTZ = time.Local
+		logger.Log.Errorf("Couldn't initialize %s timezone. Using '%s' instead", tz, RotationTZ.String())
 	}
 }
 
@@ -171,7 +171,7 @@ func (p *RotatorConfig) baseTime(now time.Time) time.Time {
 			return p.offsetDate(now, -p.KeepPartCount)
 		}
 	}
-	return time.Date(0, 0, 0, 0, 0, 0, 0, RotationLocal)
+	return time.Date(0, 0, 0, 0, 0, 0, 0, RotationTZ)
 }
 
 // AnnotateWithTime produces rotated name with custom time `v` provided as argument
@@ -179,8 +179,8 @@ func (p *RotatorConfig) AnnotateWithTime(name string, v time.Time) string {
 	if p == nil {
 		return name
 	}
-	// force use of time in RotationLocal
-	rotationalTime := v.In(RotationLocal)
+	// force use of time in RotationTZ
+	rotationalTime := v.In(RotationTZ)
 	// first of all, put date to it's bin
 	reprDate := p.getPartitionBin(rotationalTime)
 	// then convert the bin to rotated name
@@ -260,25 +260,25 @@ func (p *RotatorConfig) ParseTime(rotationTime string) (time.Time, error) {
 	switch p.PartType {
 	case RotatorPartHour:
 		if len(rotationTime) == len(HourFormat) {
-			t, err := time.ParseInLocation(HourFormat, rotationTime, RotationLocal)
+			t, err := time.ParseInLocation(HourFormat, rotationTime, RotationTZ)
 			if err != nil {
-				return time.Now(), xerrors.Errorf("cannot parse time %s in location %s: %w", rotationTime, RotationLocal.String(), err)
+				return time.Now(), xerrors.Errorf("cannot parse time %s in location %s: %w", rotationTime, RotationTZ.String(), err)
 			}
 			return t, nil
 		}
 	case RotatorPartDay:
 		if len(rotationTime) == len(DayFormat) {
-			t, err := time.ParseInLocation(DayFormat, rotationTime, RotationLocal)
+			t, err := time.ParseInLocation(DayFormat, rotationTime, RotationTZ)
 			if err != nil {
-				return time.Now(), xerrors.Errorf("cannot parse time %s in location %s: %w", rotationTime, RotationLocal.String(), err)
+				return time.Now(), xerrors.Errorf("cannot parse time %s in location %s: %w", rotationTime, RotationTZ.String(), err)
 			}
 			return t, nil
 		}
 	case RotatorPartMonth:
 		if len(rotationTime) == len(MonthFormat) {
-			t, err := time.ParseInLocation(MonthFormat, rotationTime, RotationLocal)
+			t, err := time.ParseInLocation(MonthFormat, rotationTime, RotationTZ)
 			if err != nil {
-				return time.Now(), xerrors.Errorf("cannot parser time %s in location %s: %w", rotationTime, RotationLocal.String(), err)
+				return time.Now(), xerrors.Errorf("cannot parser time %s in location %s: %w", rotationTime, RotationTZ.String(), err)
 			}
 			return t, nil
 		}

--- a/pkg/abstract/model/endpoint_rotator_config.go
+++ b/pkg/abstract/model/endpoint_rotator_config.go
@@ -3,6 +3,7 @@ package model
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -12,14 +13,21 @@ import (
 	"github.com/doublecloud/transfer/pkg/abstract"
 )
 
-// LocationEuropeMoscow -- all time in rotator considered as Moscow time
-var LocationEuropeMoscow *time.Location
+// RotationLocal -- rotation is happened in preconfigured timezone, by default - Europe/Moscow
+var RotationLocal *time.Location
 
 func init() {
 	var err error
-	if LocationEuropeMoscow, err = time.LoadLocation("Europe/Moscow"); err != nil {
-		LocationEuropeMoscow = time.Local
-		logger.Log.Errorf("Couldn't initialize Europe/Moscow timezone. Using '%s' instead", LocationEuropeMoscow.String())
+	if tz, ok := os.LookupEnv("ROTATION_TZ"); ok {
+		if RotationLocal, err = time.LoadLocation(tz); err != nil {
+			RotationLocal = time.Local
+			logger.Log.Errorf("Couldn't initialize %s timezone. Using '%s' instead", tz, RotationLocal.String())
+		}
+		return
+	}
+	if RotationLocal, err = time.LoadLocation("Europe/Moscow"); err != nil {
+		RotationLocal = time.Local
+		logger.Log.Errorf("Couldn't initialize Europe/Moscow timezone. Using '%s' instead", RotationLocal.String())
 	}
 }
 
@@ -166,7 +174,7 @@ func (p *RotatorConfig) baseTime(now time.Time) time.Time {
 			return p.offsetDate(now, -p.KeepPartCount)
 		}
 	}
-	return time.Date(0, 0, 0, 0, 0, 0, 0, LocationEuropeMoscow)
+	return time.Date(0, 0, 0, 0, 0, 0, 0, RotationLocal)
 }
 
 // AnnotateWithTime produces rotated name with custom time `v` provided as argument
@@ -174,10 +182,10 @@ func (p *RotatorConfig) AnnotateWithTime(name string, v time.Time) string {
 	if p == nil {
 		return name
 	}
-	// force use of Moscow time
-	moscowTime := v.In(LocationEuropeMoscow)
+	// force use of time in RotationLocal
+	rotationalTime := v.In(RotationLocal)
 	// first of all, put date to it's bin
-	reprDate := p.getPartitionBin(moscowTime)
+	reprDate := p.getPartitionBin(rotationalTime)
 	// then convert the bin to rotated name
 	partition := p.dateBinToPartitionName(reprDate)
 	// format text according to user expectations
@@ -190,7 +198,7 @@ func (p *RotatorConfig) Annotate(name string) string {
 	return p.AnnotateWithTime(name, time.Now())
 }
 
-// Next returns next rotated name with respect to current date
+// Next returns rotated name with respect to current date
 func (p *RotatorConfig) Next(name string) string {
 	return p.AnnotateWithTime(name, p.offsetDate(time.Now(), 1))
 }
@@ -248,32 +256,32 @@ func ExtractTimeCol(item abstract.ChangeItem, timeColumn string) time.Time {
 	return partKey
 }
 
-func (p *RotatorConfig) ParseTime(moscowTimeString string) (time.Time, error) {
+func (p *RotatorConfig) ParseTime(rotationTime string) (time.Time, error) {
 	if p == nil {
 		return time.Now(), xerrors.New("nil rotator in time parsing")
 	}
 	switch p.PartType {
 	case RotatorPartHour:
-		if len(moscowTimeString) == len(HourFormat) {
-			t, err := time.ParseInLocation(HourFormat, moscowTimeString, LocationEuropeMoscow)
+		if len(rotationTime) == len(HourFormat) {
+			t, err := time.ParseInLocation(HourFormat, rotationTime, RotationLocal)
 			if err != nil {
-				return time.Now(), xerrors.Errorf("cannot parse time %s in location %s: %w", moscowTimeString, LocationEuropeMoscow.String(), err)
+				return time.Now(), xerrors.Errorf("cannot parse time %s in location %s: %w", rotationTime, RotationLocal.String(), err)
 			}
 			return t, nil
 		}
 	case RotatorPartDay:
-		if len(moscowTimeString) == len(DayFormat) {
-			t, err := time.ParseInLocation(DayFormat, moscowTimeString, LocationEuropeMoscow)
+		if len(rotationTime) == len(DayFormat) {
+			t, err := time.ParseInLocation(DayFormat, rotationTime, RotationLocal)
 			if err != nil {
-				return time.Now(), xerrors.Errorf("cannot parse time %s in location %s: %w", moscowTimeString, LocationEuropeMoscow.String(), err)
+				return time.Now(), xerrors.Errorf("cannot parse time %s in location %s: %w", rotationTime, RotationLocal.String(), err)
 			}
 			return t, nil
 		}
 	case RotatorPartMonth:
-		if len(moscowTimeString) == len(MonthFormat) {
-			t, err := time.ParseInLocation(MonthFormat, moscowTimeString, LocationEuropeMoscow)
+		if len(rotationTime) == len(MonthFormat) {
+			t, err := time.ParseInLocation(MonthFormat, rotationTime, RotationLocal)
 			if err != nil {
-				return time.Now(), xerrors.Errorf("cannot parser time %s in location %s: %w", moscowTimeString, LocationEuropeMoscow.String(), err)
+				return time.Now(), xerrors.Errorf("cannot parser time %s in location %s: %w", rotationTime, RotationLocal.String(), err)
 			}
 			return t, nil
 		}

--- a/pkg/abstract/model/endpoint_rotator_config.go
+++ b/pkg/abstract/model/endpoint_rotator_config.go
@@ -18,16 +18,13 @@ var RotationLocal *time.Location
 
 func init() {
 	var err error
-	if tz, ok := os.LookupEnv("ROTATION_TZ"); ok {
-		if RotationLocal, err = time.LoadLocation(tz); err != nil {
-			RotationLocal = time.Local
-			logger.Log.Errorf("Couldn't initialize %s timezone. Using '%s' instead", tz, RotationLocal.String())
-		}
-		return
+	tz := "Europe/Moscow"
+	if ttz, ok := os.LookupEnv("ROTATION_TZ"); ok {
+		tz = ttz
 	}
-	if RotationLocal, err = time.LoadLocation("Europe/Moscow"); err != nil {
+	if RotationLocal, err = time.LoadLocation(tz); err != nil {
 		RotationLocal = time.Local
-		logger.Log.Errorf("Couldn't initialize Europe/Moscow timezone. Using '%s' instead", RotationLocal.String())
+		logger.Log.Errorf("Couldn't initialize %s timezone. Using '%s' instead", tz, RotationLocal.String())
 	}
 }
 

--- a/pkg/abstract/model/endpoint_rotator_config_test.go
+++ b/pkg/abstract/model/endpoint_rotator_config_test.go
@@ -294,7 +294,7 @@ func offsetDateTestMonthHeavy(t *testing.T) {
 		nowTimestamp := time.Now()
 		for offset := 1; offset < 15; offset++ {
 			for monthID, month := range monthList {
-				// NOTE UTC parameter in tests! This test will not work for RotationLocal timezone with +1 and -1 correction hours
+				// NOTE UTC parameter in tests! This test will not work for RotationTZ timezone with +1 and -1 correction hours
 				ts := time.Date(year, month, nowTimestamp.Day(), nowTimestamp.Hour(), nowTimestamp.Minute(), nowTimestamp.Second(), nowTimestamp.Nanosecond(), time.UTC)
 				offTimestamp := rcMonths.offsetDate(ts, offset)
 
@@ -339,7 +339,7 @@ func getPartitionBin(t *testing.T) {
 
 func dateBinToPartitionNameTest(t *testing.T) {
 	t.Parallel()
-	date := time.Date(2006, time.January, 2, 15, 04, 05, 0, RotationLocal)
+	date := time.Date(2006, time.January, 2, 15, 04, 05, 0, RotationTZ)
 	hourRotator := RotatorConfig{PartType: RotatorPartHour}
 	dayRotator := RotatorConfig{PartType: RotatorPartDay}
 	monthRotator := RotatorConfig{PartType: RotatorPartMonth}
@@ -380,7 +380,7 @@ func annotateWithTimeFromColumnTestWithoutFormatHours(t *testing.T) {
 	var timestamp time.Time
 
 	rc = RotatorConfig{PartType: partType, TimeColumn: timeColumn}
-	timestamp = time.Date(1987, time.July, 14, 23, 21, 45, 0, RotationLocal)
+	timestamp = time.Date(1987, time.July, 14, 23, 21, 45, 0, RotationTZ)
 	changeItem := abstract.ChangeItem{
 		ColumnNames:  []string{timeColumn},
 		ColumnValues: []interface{}{timestamp},
@@ -428,7 +428,7 @@ func annotateWithTimeFromColumnTestWithoutFormatDays(t *testing.T) {
 	var timestamp time.Time
 
 	rc = RotatorConfig{PartType: partType, TimeColumn: timeColumn}
-	timestamp = time.Date(1997, time.May, 31, 8, 12, 03, 1337, RotationLocal)
+	timestamp = time.Date(1997, time.May, 31, 8, 12, 03, 1337, RotationTZ)
 	changeItem := abstract.ChangeItem{
 		ColumnNames:  []string{timeColumn},
 		ColumnValues: []interface{}{timestamp},
@@ -484,7 +484,7 @@ func annotateWithTimeFromColumnTestWithoutFormatMonths(t *testing.T) {
 	var timestamp time.Time
 
 	rc = RotatorConfig{PartType: partType, TimeColumn: timeColumn}
-	timestamp = time.Date(2002, time.December, 13, 16, 47, 00, 691832, RotationLocal)
+	timestamp = time.Date(2002, time.December, 13, 16, 47, 00, 691832, RotationTZ)
 	changeItem := abstract.ChangeItem{
 		ColumnNames:  []string{timeColumn},
 		ColumnValues: []interface{}{timestamp},
@@ -521,7 +521,7 @@ func annotateWithTimeFromColumnTestWithTemplateHours(t *testing.T) {
 	var timestamp time.Time
 
 	rc = RotatorConfig{PartType: partType, TimeColumn: timeColumn, TableNameTemplate: format}
-	timestamp = time.Date(1430, time.January, 10, 23, 8, 30, 143721739, RotationLocal)
+	timestamp = time.Date(1430, time.January, 10, 23, 8, 30, 143721739, RotationTZ)
 	changeItem := abstract.ChangeItem{
 		ColumnNames:  []string{timeColumn},
 		ColumnValues: []interface{}{timestamp},
@@ -570,7 +570,7 @@ func annotateWithTimeFromColumnTestWithFormatDays(t *testing.T) {
 	var timestamp time.Time
 
 	rc = RotatorConfig{PartType: partType, TimeColumn: timeColumn, TableNameTemplate: format}
-	timestamp = time.Date(2400, time.February, 29, 3, 56, 28, 7005194, RotationLocal)
+	timestamp = time.Date(2400, time.February, 29, 3, 56, 28, 7005194, RotationTZ)
 	changeItem := abstract.ChangeItem{
 		ColumnNames:  []string{timeColumn},
 		ColumnValues: []interface{}{timestamp},
@@ -627,7 +627,7 @@ func annotateWithTimeFromColumnTestWithFormatMonths(t *testing.T) {
 	var timestamp time.Time
 
 	rc = RotatorConfig{PartType: partType, TimeColumn: timeColumn, TableNameTemplate: format}
-	timestamp = time.Date(2021, time.July, 1, 19, 27, 52, 7005194, RotationLocal)
+	timestamp = time.Date(2021, time.July, 1, 19, 27, 52, 7005194, RotationTZ)
 	changeItem := abstract.ChangeItem{
 		ColumnNames:  []string{timeColumn},
 		ColumnValues: []interface{}{timestamp},
@@ -660,7 +660,7 @@ func annotateWithTimeFromColumnTestNoTimeColumnInRawData(t *testing.T) {
 	rc := RotatorConfig{PartType: RotatorPartHour, TimeColumn: timeColumn, PartSize: 1}
 	changeItem := abstract.ChangeItem{
 		ColumnNames:  []string{"top", "kek", "che", "bu", "rek", "rime_column"},
-		ColumnValues: []interface{}{"yehal", "greka", "che", "rez", "reku", time.Date(1909, time.May, 3, 12, 17, 32, 0, RotationLocal)},
+		ColumnValues: []interface{}{"yehal", "greka", "che", "rez", "reku", time.Date(1909, time.May, 3, 12, 17, 32, 0, RotationTZ)},
 	}
 	annotate1 := rc.Annotate("Roga-I-Kopyta")
 	annotate2 := rc.AnnotateWithTimeFromColumn("Roga-I-Kopyta", changeItem)
@@ -677,7 +677,7 @@ func annotateWithTimeFromColumnTestNoTimeColumnInConfig(t *testing.T) {
 	rc := RotatorConfig{PartType: RotatorPartHour, PartSize: 1}
 	changeItem := abstract.ChangeItem{
 		ColumnNames:  []string{"time_column"},
-		ColumnValues: []interface{}{time.Date(1927, time.August, 15, 19, 12, 38, 0, RotationLocal)},
+		ColumnValues: []interface{}{time.Date(1927, time.August, 15, 19, 12, 38, 0, RotationTZ)},
 	}
 	annotate1 := rc.Annotate("KostyaLososInc")
 	annotate2 := rc.AnnotateWithTimeFromColumn("KostyaLososInc", changeItem)
@@ -694,7 +694,7 @@ func annotateWithTimeFromColumnTestNilReceiver(t *testing.T) {
 	var nilRotator *RotatorConfig
 	changeItem := abstract.ChangeItem{
 		ColumnNames:  []string{"time_column"},
-		ColumnValues: []interface{}{time.Date(1927, time.April, 16, 13, 22, 5, 0, RotationLocal)},
+		ColumnValues: []interface{}{time.Date(1927, time.April, 16, 13, 22, 5, 0, RotationTZ)},
 	}
 
 	annotate1 := nilRotator.Annotate("ElonMusksTable")
@@ -750,9 +750,9 @@ func testTimeParsingHours(t *testing.T) {
 	rotator := RotatorConfig{PartType: RotatorPartHour}
 
 	for rotationalTime, expected := range map[string]time.Time{
-		"1575-01-14T17:17:29": time.Date(1575, time.January, 14, 17, 17, 29, 0, RotationLocal),
-		"2021-08-06T01:29:43": time.Date(2021, time.August, 06, 01, 29, 43, 0, RotationLocal),
-		"2004-02-29T06:11:58": time.Date(2004, time.February, 29, 06, 11, 58, 0, RotationLocal),
+		"1575-01-14T17:17:29": time.Date(1575, time.January, 14, 17, 17, 29, 0, RotationTZ),
+		"2021-08-06T01:29:43": time.Date(2021, time.August, 06, 01, 29, 43, 0, RotationTZ),
+		"2004-02-29T06:11:58": time.Date(2004, time.February, 29, 06, 11, 58, 0, RotationTZ),
 	} {
 		actual, err := rotator.ParseTime(rotationalTime)
 		require.NoError(t, err)
@@ -765,9 +765,9 @@ func testTimeParsingDays(t *testing.T) {
 	rotator := RotatorConfig{PartType: RotatorPartDay}
 
 	for rotationTime, expected := range map[string]time.Time{
-		"1575-01-14": time.Date(1575, time.January, 14, 0, 0, 0, 0, RotationLocal),
-		"2021-08-06": time.Date(2021, time.August, 06, 0, 0, 0, 0, RotationLocal),
-		"2004-02-29": time.Date(2004, time.February, 29, 0, 0, 0, 0, RotationLocal),
+		"1575-01-14": time.Date(1575, time.January, 14, 0, 0, 0, 0, RotationTZ),
+		"2021-08-06": time.Date(2021, time.August, 06, 0, 0, 0, 0, RotationTZ),
+		"2004-02-29": time.Date(2004, time.February, 29, 0, 0, 0, 0, RotationTZ),
 	} {
 		actual, err := rotator.ParseTime(rotationTime)
 		require.NoError(t, err)
@@ -780,9 +780,9 @@ func testTimeParsingMonths(t *testing.T) {
 	rotator := RotatorConfig{PartType: RotatorPartMonth}
 
 	for rotationTime, expected := range map[string]time.Time{
-		"1575-01": time.Date(1575, time.January, 1, 0, 0, 0, 0, RotationLocal),
-		"2021-08": time.Date(2021, time.August, 1, 0, 0, 0, 0, RotationLocal),
-		"2004-02": time.Date(2004, time.February, 1, 0, 0, 0, 0, RotationLocal),
+		"1575-01": time.Date(1575, time.January, 1, 0, 0, 0, 0, RotationTZ),
+		"2021-08": time.Date(2021, time.August, 1, 0, 0, 0, 0, RotationTZ),
+		"2004-02": time.Date(2004, time.February, 1, 0, 0, 0, 0, RotationTZ),
 	} {
 		actual, err := rotator.ParseTime(rotationTime)
 		require.NoError(t, err)

--- a/pkg/abstract/model/endpoint_rotator_config_test.go
+++ b/pkg/abstract/model/endpoint_rotator_config_test.go
@@ -294,7 +294,7 @@ func offsetDateTestMonthHeavy(t *testing.T) {
 		nowTimestamp := time.Now()
 		for offset := 1; offset < 15; offset++ {
 			for monthID, month := range monthList {
-				// NOTE UTC parameter in tests! This test will not work for LocationEuropeMoscow timezone with +1 and -1 correction hours
+				// NOTE UTC parameter in tests! This test will not work for RotationLocal timezone with +1 and -1 correction hours
 				ts := time.Date(year, month, nowTimestamp.Day(), nowTimestamp.Hour(), nowTimestamp.Minute(), nowTimestamp.Second(), nowTimestamp.Nanosecond(), time.UTC)
 				offTimestamp := rcMonths.offsetDate(ts, offset)
 
@@ -339,7 +339,7 @@ func getPartitionBin(t *testing.T) {
 
 func dateBinToPartitionNameTest(t *testing.T) {
 	t.Parallel()
-	date := time.Date(2006, time.January, 2, 15, 04, 05, 0, LocationEuropeMoscow)
+	date := time.Date(2006, time.January, 2, 15, 04, 05, 0, RotationLocal)
 	hourRotator := RotatorConfig{PartType: RotatorPartHour}
 	dayRotator := RotatorConfig{PartType: RotatorPartDay}
 	monthRotator := RotatorConfig{PartType: RotatorPartMonth}
@@ -380,7 +380,7 @@ func annotateWithTimeFromColumnTestWithoutFormatHours(t *testing.T) {
 	var timestamp time.Time
 
 	rc = RotatorConfig{PartType: partType, TimeColumn: timeColumn}
-	timestamp = time.Date(1987, time.July, 14, 23, 21, 45, 0, LocationEuropeMoscow)
+	timestamp = time.Date(1987, time.July, 14, 23, 21, 45, 0, RotationLocal)
 	changeItem := abstract.ChangeItem{
 		ColumnNames:  []string{timeColumn},
 		ColumnValues: []interface{}{timestamp},
@@ -428,7 +428,7 @@ func annotateWithTimeFromColumnTestWithoutFormatDays(t *testing.T) {
 	var timestamp time.Time
 
 	rc = RotatorConfig{PartType: partType, TimeColumn: timeColumn}
-	timestamp = time.Date(1997, time.May, 31, 8, 12, 03, 1337, LocationEuropeMoscow)
+	timestamp = time.Date(1997, time.May, 31, 8, 12, 03, 1337, RotationLocal)
 	changeItem := abstract.ChangeItem{
 		ColumnNames:  []string{timeColumn},
 		ColumnValues: []interface{}{timestamp},
@@ -484,7 +484,7 @@ func annotateWithTimeFromColumnTestWithoutFormatMonths(t *testing.T) {
 	var timestamp time.Time
 
 	rc = RotatorConfig{PartType: partType, TimeColumn: timeColumn}
-	timestamp = time.Date(2002, time.December, 13, 16, 47, 00, 691832, LocationEuropeMoscow)
+	timestamp = time.Date(2002, time.December, 13, 16, 47, 00, 691832, RotationLocal)
 	changeItem := abstract.ChangeItem{
 		ColumnNames:  []string{timeColumn},
 		ColumnValues: []interface{}{timestamp},
@@ -521,7 +521,7 @@ func annotateWithTimeFromColumnTestWithTemplateHours(t *testing.T) {
 	var timestamp time.Time
 
 	rc = RotatorConfig{PartType: partType, TimeColumn: timeColumn, TableNameTemplate: format}
-	timestamp = time.Date(1430, time.January, 10, 23, 8, 30, 143721739, LocationEuropeMoscow)
+	timestamp = time.Date(1430, time.January, 10, 23, 8, 30, 143721739, RotationLocal)
 	changeItem := abstract.ChangeItem{
 		ColumnNames:  []string{timeColumn},
 		ColumnValues: []interface{}{timestamp},
@@ -570,7 +570,7 @@ func annotateWithTimeFromColumnTestWithFormatDays(t *testing.T) {
 	var timestamp time.Time
 
 	rc = RotatorConfig{PartType: partType, TimeColumn: timeColumn, TableNameTemplate: format}
-	timestamp = time.Date(2400, time.February, 29, 3, 56, 28, 7005194, LocationEuropeMoscow)
+	timestamp = time.Date(2400, time.February, 29, 3, 56, 28, 7005194, RotationLocal)
 	changeItem := abstract.ChangeItem{
 		ColumnNames:  []string{timeColumn},
 		ColumnValues: []interface{}{timestamp},
@@ -627,7 +627,7 @@ func annotateWithTimeFromColumnTestWithFormatMonths(t *testing.T) {
 	var timestamp time.Time
 
 	rc = RotatorConfig{PartType: partType, TimeColumn: timeColumn, TableNameTemplate: format}
-	timestamp = time.Date(2021, time.July, 1, 19, 27, 52, 7005194, LocationEuropeMoscow)
+	timestamp = time.Date(2021, time.July, 1, 19, 27, 52, 7005194, RotationLocal)
 	changeItem := abstract.ChangeItem{
 		ColumnNames:  []string{timeColumn},
 		ColumnValues: []interface{}{timestamp},
@@ -660,7 +660,7 @@ func annotateWithTimeFromColumnTestNoTimeColumnInRawData(t *testing.T) {
 	rc := RotatorConfig{PartType: RotatorPartHour, TimeColumn: timeColumn, PartSize: 1}
 	changeItem := abstract.ChangeItem{
 		ColumnNames:  []string{"top", "kek", "che", "bu", "rek", "rime_column"},
-		ColumnValues: []interface{}{"yehal", "greka", "che", "rez", "reku", time.Date(1909, time.May, 3, 12, 17, 32, 0, LocationEuropeMoscow)},
+		ColumnValues: []interface{}{"yehal", "greka", "che", "rez", "reku", time.Date(1909, time.May, 3, 12, 17, 32, 0, RotationLocal)},
 	}
 	annotate1 := rc.Annotate("Roga-I-Kopyta")
 	annotate2 := rc.AnnotateWithTimeFromColumn("Roga-I-Kopyta", changeItem)
@@ -677,7 +677,7 @@ func annotateWithTimeFromColumnTestNoTimeColumnInConfig(t *testing.T) {
 	rc := RotatorConfig{PartType: RotatorPartHour, PartSize: 1}
 	changeItem := abstract.ChangeItem{
 		ColumnNames:  []string{"time_column"},
-		ColumnValues: []interface{}{time.Date(1927, time.August, 15, 19, 12, 38, 0, LocationEuropeMoscow)},
+		ColumnValues: []interface{}{time.Date(1927, time.August, 15, 19, 12, 38, 0, RotationLocal)},
 	}
 	annotate1 := rc.Annotate("KostyaLososInc")
 	annotate2 := rc.AnnotateWithTimeFromColumn("KostyaLososInc", changeItem)
@@ -694,7 +694,7 @@ func annotateWithTimeFromColumnTestNilReceiver(t *testing.T) {
 	var nilRotator *RotatorConfig
 	changeItem := abstract.ChangeItem{
 		ColumnNames:  []string{"time_column"},
-		ColumnValues: []interface{}{time.Date(1927, time.April, 16, 13, 22, 5, 0, LocationEuropeMoscow)},
+		ColumnValues: []interface{}{time.Date(1927, time.April, 16, 13, 22, 5, 0, RotationLocal)},
 	}
 
 	annotate1 := nilRotator.Annotate("ElonMusksTable")
@@ -749,12 +749,12 @@ func testTimeParsingHours(t *testing.T) {
 	t.Parallel()
 	rotator := RotatorConfig{PartType: RotatorPartHour}
 
-	for timeAsMoscowString, expected := range map[string]time.Time{
-		"1575-01-14T17:17:29": time.Date(1575, time.January, 14, 17, 17, 29, 0, LocationEuropeMoscow),
-		"2021-08-06T01:29:43": time.Date(2021, time.August, 06, 01, 29, 43, 0, LocationEuropeMoscow),
-		"2004-02-29T06:11:58": time.Date(2004, time.February, 29, 06, 11, 58, 0, LocationEuropeMoscow),
+	for rotationalTime, expected := range map[string]time.Time{
+		"1575-01-14T17:17:29": time.Date(1575, time.January, 14, 17, 17, 29, 0, RotationLocal),
+		"2021-08-06T01:29:43": time.Date(2021, time.August, 06, 01, 29, 43, 0, RotationLocal),
+		"2004-02-29T06:11:58": time.Date(2004, time.February, 29, 06, 11, 58, 0, RotationLocal),
 	} {
-		actual, err := rotator.ParseTime(timeAsMoscowString)
+		actual, err := rotator.ParseTime(rotationalTime)
 		require.NoError(t, err)
 		require.Equal(t, expected, actual)
 	}
@@ -764,12 +764,12 @@ func testTimeParsingDays(t *testing.T) {
 	t.Parallel()
 	rotator := RotatorConfig{PartType: RotatorPartDay}
 
-	for timeAsMoscowString, expected := range map[string]time.Time{
-		"1575-01-14": time.Date(1575, time.January, 14, 0, 0, 0, 0, LocationEuropeMoscow),
-		"2021-08-06": time.Date(2021, time.August, 06, 0, 0, 0, 0, LocationEuropeMoscow),
-		"2004-02-29": time.Date(2004, time.February, 29, 0, 0, 0, 0, LocationEuropeMoscow),
+	for rotationTime, expected := range map[string]time.Time{
+		"1575-01-14": time.Date(1575, time.January, 14, 0, 0, 0, 0, RotationLocal),
+		"2021-08-06": time.Date(2021, time.August, 06, 0, 0, 0, 0, RotationLocal),
+		"2004-02-29": time.Date(2004, time.February, 29, 0, 0, 0, 0, RotationLocal),
 	} {
-		actual, err := rotator.ParseTime(timeAsMoscowString)
+		actual, err := rotator.ParseTime(rotationTime)
 		require.NoError(t, err)
 		require.Equal(t, expected, actual)
 	}
@@ -779,12 +779,12 @@ func testTimeParsingMonths(t *testing.T) {
 	t.Parallel()
 	rotator := RotatorConfig{PartType: RotatorPartMonth}
 
-	for timeAsMoscowString, expected := range map[string]time.Time{
-		"1575-01": time.Date(1575, time.January, 1, 0, 0, 0, 0, LocationEuropeMoscow),
-		"2021-08": time.Date(2021, time.August, 1, 0, 0, 0, 0, LocationEuropeMoscow),
-		"2004-02": time.Date(2004, time.February, 1, 0, 0, 0, 0, LocationEuropeMoscow),
+	for rotationTime, expected := range map[string]time.Time{
+		"1575-01": time.Date(1575, time.January, 1, 0, 0, 0, 0, RotationLocal),
+		"2021-08": time.Date(2021, time.August, 1, 0, 0, 0, 0, RotationLocal),
+		"2004-02": time.Date(2004, time.February, 1, 0, 0, 0, 0, RotationLocal),
 	} {
-		actual, err := rotator.ParseTime(timeAsMoscowString)
+		actual, err := rotator.ParseTime(rotationTime)
 		require.NoError(t, err)
 		require.Equal(t, expected, actual)
 	}


### PR DESCRIPTION
Before it was hard-coded to Moscow TZ, which is not convinient, so make it configurable with new ENV variable - `ROTATION_TZ`, and make it defaulted to UTC in opensouce docker package

closes #136