### PR TITLE
Fix yaml transformer parsing

### DIFF
--- a/cmd/trcli/config/config.go
+++ b/cmd/trcli/config/config.go
@@ -12,7 +12,7 @@ import (
 	"github.com/doublecloud/transfer/pkg/abstract/model"
 	"github.com/doublecloud/transfer/pkg/transformer"
 	"github.com/mitchellh/mapstructure"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	sig_yaml "sigs.k8s.io/yaml"
 )
 


### PR DESCRIPTION
`gopkg.in/yaml.v2` produces `map[interface{}]interface{}` when reading a map with strings keys, which `encoding/json` fails to marshal at https://github.com/doublecloud/transfer/blob/79cb2abd01839784c97e914afacc2a90a25f83a8/pkg/abstract/model/transfer.go#L242 returning `json: unsupported type: map[interface {}]interface {}`.

Using yaml.v3 fixes this issue, and the correct JSON representation is returned:

```
{"debugMode":false,"transformers":[{"renameTables":{"errorsoutput":null,"renameTables":[{"newName":{"name":"channel_participant_events","nameSpace":""},"originalName":{"name":"CHANNEL_PARTICIPANT","nameSpace":"SOCIAL_DB"}}],"transformerId":""}}],"errorsOutput":null}
```

Reference: https://github.com/go-yaml/yaml/issues/591