### PR TITLE
Replace deprecated code

### DIFF
--- a/internal/config/nirvana.go
+++ b/internal/config/nirvana.go
@@ -3,7 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 type JobContext struct {
@@ -35,7 +35,7 @@ type JobContext struct {
 }
 
 func TryParseNirvanaConfig() (*Config, error) {
-	dat, err := ioutil.ReadFile("job_context.json")
+	dat, err := os.ReadFile("job_context.json")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/metrics/pidstat.go
+++ b/internal/metrics/pidstat.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
+	"os"
 	"os/exec"
 	"path"
 	"runtime"
@@ -78,7 +78,7 @@ func stat(pid int, statType string) (*SysInfo, error) {
 		var clkTck float64 = 100
 		var pageSize float64 = 4096
 
-		uptimeFileBytes, _ := ioutil.ReadFile(path.Join("/proc", "uptime"))
+		uptimeFileBytes, _ := os.ReadFile(path.Join("/proc", "uptime"))
 		uptime := parseFloat(strings.Split(string(uptimeFileBytes), " ")[0])
 
 		clkTckStdout, err := exec.Command("getconf", "CLK_TCK").Output()
@@ -91,7 +91,7 @@ func stat(pid int, statType string) (*SysInfo, error) {
 			pageSize = parseFloat(formatStdOut(pageSizeStdout, 0)[0])
 		}
 
-		procStatFileBytes, _ := ioutil.ReadFile(path.Join("/proc", strconv.Itoa(pid), "stat"))
+		procStatFileBytes, _ := os.ReadFile(path.Join("/proc", strconv.Itoa(pid), "stat"))
 		splitAfter := strings.SplitAfter(string(procStatFileBytes), ")")
 
 		if len(splitAfter) == 0 || len(splitAfter) == 1 {

--- a/pkg/providers/airbyte/storage.go
+++ b/pkg/providers/airbyte/storage.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"sort"
@@ -166,7 +166,7 @@ func (a *Storage) LoadTable(ctx context.Context, table abstract.TableDescription
 	if err := a.storeState(table.ID(), currentState); err != nil {
 		return xerrors.Errorf("unable to store incremental state: %w", err)
 	}
-	data, err := ioutil.ReadAll(stderr)
+	data, err := io.ReadAll(stderr)
 	if err != nil {
 		return xerrors.Errorf("%s stderr read all failed: %w", table.ID().String(), err)
 	}
@@ -323,7 +323,7 @@ func (a *Storage) writeFile(fileName, fileData string) error {
 	fullPath := fmt.Sprintf("%v/%v", a.config.DataDir(), fileName)
 	a.logger.Debugf("%s -> \n%s", fileName, fileData)
 	defer a.logger.Infof("file(%s) %s written", format.SizeInt(len(fileData)), fullPath)
-	return ioutil.WriteFile(
+	return os.WriteFile(
 		fullPath,
 		[]byte(fileData),
 		0664,

--- a/pkg/providers/clickhouse/httpclient/http_client_mock.go
+++ b/pkg/providers/clickhouse/httpclient/http_client_mock.go
@@ -13,8 +13,8 @@ import (
 	io "io"
 	reflect "reflect"
 
-	log "go.ytsaurus.tech/library/go/core/log"
 	gomock "go.uber.org/mock/gomock"
+	log "go.ytsaurus.tech/library/go/core/log"
 )
 
 // MockHTTPClient is a mock of HTTPClient interface.

--- a/pkg/providers/elastic/client.go
+++ b/pkg/providers/elastic/client.go
@@ -3,6 +3,7 @@ package elastic
 import (
 	"fmt"
 	"io"
+	"net"
 	"reflect"
 	"unsafe"
 

--- a/pkg/providers/elastic/client.go
+++ b/pkg/providers/elastic/client.go
@@ -2,7 +2,7 @@ package elastic
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"unsafe"
 
@@ -78,7 +78,7 @@ func ConfigFromDestination(logger log.Logger, cfg *ElasticSearchDestination, ser
 	}
 
 	if cfg.ClusterID == "" {
-		var protocol = "http"
+		protocol := "http"
 		if cfg.SSLEnabled {
 			protocol = "https"
 		}
@@ -125,7 +125,7 @@ func getResponseBody(res *esapi.Response, err error) ([]byte, error) {
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to read response body: %w", err)
 	}

--- a/pkg/providers/eventhub/eventhub_test.go
+++ b/pkg/providers/eventhub/eventhub_test.go
@@ -30,7 +30,6 @@ const (
 var namespace, hub, consumerGroup string
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
 	namespace = os.Getenv("EVENTHUB_NAMESPACE")
 	hub = os.Getenv("EVENTHUB_NAME")
 	consumerGroup = os.Getenv("EVENTHUB_CONSUMER_GROUP")

--- a/pkg/providers/kafka/writer/writer_mock.go
+++ b/pkg/providers/kafka/writer/writer_mock.go
@@ -13,11 +13,11 @@ import (
 	tls "crypto/tls"
 	reflect "reflect"
 
-	log "go.ytsaurus.tech/library/go/core/log"
 	queue "github.com/doublecloud/transfer/pkg/serializer/queue"
 	kafka "github.com/segmentio/kafka-go"
 	sasl "github.com/segmentio/kafka-go/sasl"
 	gomock "go.uber.org/mock/gomock"
+	log "go.ytsaurus.tech/library/go/core/log"
 )
 
 // MockAbstractWriter is a mock of AbstractWriter interface.

--- a/pkg/providers/mongo/local_oplog_rs_watcher.go
+++ b/pkg/providers/mongo/local_oplog_rs_watcher.go
@@ -154,7 +154,7 @@ func (w localOplogRsWatcher) watchBatchFrom(ctx context.Context, ts primitive.Ti
 	w.logger.Infof("Begin watching batch from time %v", FromMongoTimestamp(ts))
 	// check that timestamp is still in oplog
 	from, to, err := GetLocalOplogInterval(ctx, w.client)
-	if primitive.CompareTimestamp(ts, from) < 0 {
+	if ts.Compare(from) < 0 {
 		return until, eventsRead, xerrors.Errorf("local.oplog.rs watcher is out of timeline. Requested timestamp %v, actual interval: [%v, %v]",
 			FromMongoTimestamp(ts),
 			FromMongoTimestamp(from),

--- a/pkg/providers/ydb/sink.go
+++ b/pkg/providers/ydb/sink.go
@@ -818,7 +818,6 @@ func (s *sinker) insert(tablePath ydbPath, batch []abstract.ChangeItem) error {
 			}
 			return nil
 		})
-
 		if err != nil {
 			return xerrors.Errorf("unable to insert with legacy writer:\n %w", err)
 		}
@@ -1022,15 +1021,15 @@ func (s *sinker) ydbVal(dataType, originalType string, val interface{}) (types.V
 		case schema.TypeBytes:
 			switch v := val.(type) {
 			case string:
-				return types.StringValue([]byte(v)), false, nil
+				return types.BytesValue([]byte(v)), false, nil
 			case []uint8:
-				return types.StringValue(v), false, nil
+				return types.BytesValue(v), false, nil
 			default:
 				r, err := json.Marshal(val)
 				if err != nil {
 					return nil, false, xerrors.Errorf("unable to json marshal: %w", err)
 				}
-				return types.StringValue(r), false, nil
+				return types.BytesValue(r), false, nil
 			}
 		case schema.TypeString:
 			switch v := val.(type) {

--- a/pkg/providers/yt/executable.go
+++ b/pkg/providers/yt/executable.go
@@ -3,9 +3,7 @@ package yt
 import (
 	"context"
 	"io"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/doublecloud/transfer/internal/logger"
 	"github.com/doublecloud/transfer/library/go/core/xerrors"
@@ -78,7 +76,6 @@ func uploadExe(exePrefix, exePath string) error {
 	}
 	defer client.Stop()
 
-	rand.Seed(time.Now().UnixNano())
 	exeVersion = exePrefix + randutil.GenerateAlphanumericString(8)
 	ExePath = DataplaneExecutablePath("", exeVersion)
 	if _, err := client.CreateNode(context.Background(), ExePath, yt.NodeFile, &yt.CreateNodeOptions{Recursive: true}); err != nil {

--- a/pkg/providers/yt/merge/merge_test.go
+++ b/pkg/providers/yt/merge/merge_test.go
@@ -2,9 +2,7 @@ package merge
 
 import (
 	"context"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/doublecloud/transfer/internal/logger"
 	"github.com/doublecloud/transfer/library/go/core/xerrors"
@@ -43,7 +41,6 @@ func testYT(t *testing.T, testName string, test func(t *testing.T, ctx context.C
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rand.Seed(time.Now().UnixNano())
 	testDir := randutil.GenerateAlphanumericString(10)
 
 	path := yt2.SafeChild("//home/cdc/test", testName, testDir)
@@ -93,7 +90,8 @@ func TestMergeBasic(t *testing.T) {
 				{Key: "7"},
 				{Key: "8"},
 				{Key: "9"},
-			}}, false)
+			},
+		}, false)
 		nodes, err := yt2.ListNodesWithAttrs(ctx, client, path, "", false)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(nodes))
@@ -136,7 +134,8 @@ func TestMergeBasicCleanup(t *testing.T) {
 				{Key: "7"},
 				{Key: "8"},
 				{Key: "9"},
-			}}, false)
+			},
+		}, false)
 		nodes, err := yt2.ListNodesWithAttrs(ctx, client, path, "", false)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(nodes))

--- a/pkg/providers/yt/tests/util_test.go
+++ b/pkg/providers/yt/tests/util_test.go
@@ -3,9 +3,7 @@ package yt
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/doublecloud/transfer/internal/logger"
 	"github.com/doublecloud/transfer/library/go/core/xerrors"
@@ -89,7 +87,6 @@ func TestMountUnmount(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rand.Seed(time.Now().UnixNano())
 	testDir := randutil.GenerateAlphanumericString(10)
 
 	path := ypath.Path("//home/cdc/test/mount_unmount").Child(testDir)

--- a/pkg/randutil/randutil.go
+++ b/pkg/randutil/randutil.go
@@ -1,12 +1,10 @@
 package randutil
 
 import (
-	"math/rand"
+	"crypto/rand"
 )
 
-var (
-	AlphanumericValues string
-)
+var AlphanumericValues string
 
 func init() {
 	var alphanumericValues []byte

--- a/pkg/transformer/registry/lambda/lambda_test.go
+++ b/pkg/transformer/registry/lambda/lambda_test.go
@@ -3,7 +3,7 @@ package lambda
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -24,7 +24,7 @@ func TestLambdaTransformer(t *testing.T) {
 		data := functions.Data{}
 		var bodyBytes []byte
 		if r.Body != nil {
-			bodyBytes, _ = ioutil.ReadAll(r.Body)
+			bodyBytes, _ = io.ReadAll(r.Body)
 		}
 		logger.Log.Infof("request into mock server: %v", string(bodyBytes))
 		require.NoError(t, json.Unmarshal(bodyBytes, &data))

--- a/pkg/xtls/create.go
+++ b/pkg/xtls/create.go
@@ -3,7 +3,7 @@ package xtls
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 
 	"github.com/doublecloud/transfer/library/go/core/xerrors"
 )
@@ -14,7 +14,7 @@ func Pool(rootCACertPaths []string) (*x509.CertPool, error) {
 		return nil, err
 	}
 	for _, certPath := range rootCACertPaths {
-		caCertificatePEM, err := ioutil.ReadFile(certPath)
+		caCertificatePEM, err := os.ReadFile(certPath)
 		if err != nil {
 			return nil, xerrors.Errorf("Cannot read file %s: %w", certPath, err)
 		}

--- a/tests/canon/reference/reference.go
+++ b/tests/canon/reference/reference.go
@@ -3,7 +3,6 @@ package reference
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -65,7 +64,7 @@ func ReferenceTestFn(transfer *model.Transfer, sinkAsSource model.Source, items 
 				cwd, err := os.Getwd()
 				require.NoError(t, err)
 				fileForResult := filepath.Join(cwd, "result.txt")
-				require.NoError(t, ioutil.WriteFile(fileForResult, marshalledResult, 0o666))
+				require.NoError(t, os.WriteFile(fileForResult, marshalledResult, 0o666))
 
 				canon.SaveFile(t, fileForResult)
 			})

--- a/tests/e2e/mysql2mock/debezium/debezium_replication/check_db_test.go
+++ b/tests/e2e/mysql2mock/debezium/debezium_replication/check_db_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync"
 	"testing"
@@ -168,7 +167,7 @@ INSERT INTO customers3 VALUES (
 
 func ReadTextFiles(paths []string, out []*string) error {
 	for index, path := range paths {
-		valArr, err := ioutil.ReadFile(yatest.SourcePath(path))
+		valArr, err := os.ReadFile(yatest.SourcePath(path))
 		if err != nil {
 			return xerrors.Errorf("unable to read file %s: %w", path, err)
 		}

--- a/tests/e2e/mysql2mock/debezium/debezium_snapshot/check_db_test.go
+++ b/tests/e2e/mysql2mock/debezium/debezium_snapshot/check_db_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -33,9 +32,9 @@ func TestSnapshot(t *testing.T) {
 		helpers.LabeledPort{Label: "mysql source", Port: Source.Port},
 	))
 
-	canonizedDebeziumKeyBytes, err := ioutil.ReadFile(yatest.SourcePath("transfer_manager/go/tests/e2e/mysql2mock/debezium/debezium_snapshot/testdata/change_item_key.txt"))
+	canonizedDebeziumKeyBytes, err := os.ReadFile(yatest.SourcePath("transfer_manager/go/tests/e2e/mysql2mock/debezium/debezium_snapshot/testdata/change_item_key.txt"))
 	require.NoError(t, err)
-	canonizedDebeziumValBytes, err := ioutil.ReadFile(yatest.SourcePath("transfer_manager/go/tests/e2e/mysql2mock/debezium/debezium_snapshot/testdata/change_item_val.txt"))
+	canonizedDebeziumValBytes, err := os.ReadFile(yatest.SourcePath("transfer_manager/go/tests/e2e/mysql2mock/debezium/debezium_snapshot/testdata/change_item_val.txt"))
 	require.NoError(t, err)
 	canonizedDebeziumVal := string(canonizedDebeziumValBytes)
 

--- a/tests/e2e/pg2mock/debezium/debezium_replication/check_db_test.go
+++ b/tests/e2e/pg2mock/debezium/debezium_replication/check_db_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync"
 	"testing"
@@ -154,7 +153,7 @@ INSERT INTO public.basic_types VALUES (
 
 func ReadTextFiles(paths []string, out []*string) error {
 	for index, path := range paths {
-		valArr, err := ioutil.ReadFile(yatest.SourcePath(path))
+		valArr, err := os.ReadFile(yatest.SourcePath(path))
 		if err != nil {
 			return xerrors.Errorf("unable to read file %s: %w", path, err)
 		}

--- a/tests/e2e/pg2mock/debezium/debezium_replication_arr/check_db_test.go
+++ b/tests/e2e/pg2mock/debezium/debezium_replication_arr/check_db_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync"
 	"testing"
@@ -106,7 +105,7 @@ INSERT INTO public.basic_types VALUES (
 
 func ReadTextFiles(paths []string, out []*string) error {
 	for index, path := range paths {
-		valArr, err := ioutil.ReadFile(yatest.SourcePath(path))
+		valArr, err := os.ReadFile(yatest.SourcePath(path))
 		if err != nil {
 			return xerrors.Errorf("unable to read file %s: %w", path, err)
 		}

--- a/tests/e2e/pg2mock/debezium/debezium_replication_replica_identity/check_db_test.go
+++ b/tests/e2e/pg2mock/debezium/debezium_replication_replica_identity/check_db_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync"
 	"testing"
@@ -33,7 +32,7 @@ func init() {
 
 func ReadTextFiles(paths []string, out []*string) error {
 	for index, path := range paths {
-		valArr, err := ioutil.ReadFile(yatest.SourcePath(path))
+		valArr, err := os.ReadFile(yatest.SourcePath(path))
 		if err != nil {
 			return xerrors.Errorf("unable to read file %s: %w", path, err)
 		}

--- a/tests/e2e/pg2mock/debezium/debezium_snapshot/check_db_test.go
+++ b/tests/e2e/pg2mock/debezium/debezium_snapshot/check_db_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -33,9 +32,9 @@ func TestSnapshot(t *testing.T) {
 		helpers.LabeledPort{Label: "PG source", Port: Source.Port},
 	))
 
-	canonizedDebeziumKeyBytes, err := ioutil.ReadFile(yatest.SourcePath("transfer_manager/go/tests/e2e/pg2mock/debezium/debezium_snapshot/testdata/change_item_key.txt"))
+	canonizedDebeziumKeyBytes, err := os.ReadFile(yatest.SourcePath("transfer_manager/go/tests/e2e/pg2mock/debezium/debezium_snapshot/testdata/change_item_key.txt"))
 	require.NoError(t, err)
-	canonizedDebeziumValBytes, err := ioutil.ReadFile(yatest.SourcePath("transfer_manager/go/tests/e2e/pg2mock/debezium/debezium_snapshot/testdata/change_item_val.txt"))
+	canonizedDebeziumValBytes, err := os.ReadFile(yatest.SourcePath("transfer_manager/go/tests/e2e/pg2mock/debezium/debezium_snapshot/testdata/change_item_val.txt"))
 	require.NoError(t, err)
 	canonizedDebeziumVal := string(canonizedDebeziumValBytes)
 

--- a/tests/e2e/pg2mock/debezium/debezium_snapshot_arr/check_db_test.go
+++ b/tests/e2e/pg2mock/debezium/debezium_snapshot_arr/check_db_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -32,9 +31,9 @@ func TestSnapshot(t *testing.T) {
 		helpers.LabeledPort{Label: "PG source", Port: Source.Port},
 	))
 
-	canonizedDebeziumKeyArr, err := ioutil.ReadFile(yatest.SourcePath("transfer_manager/go/tests/e2e/pg2mock/debezium/debezium_snapshot_arr/testdata/change_item_key.txt"))
+	canonizedDebeziumKeyArr, err := os.ReadFile(yatest.SourcePath("transfer_manager/go/tests/e2e/pg2mock/debezium/debezium_snapshot_arr/testdata/change_item_key.txt"))
 	require.NoError(t, err)
-	canonizedDebeziumValArr, err := ioutil.ReadFile(yatest.SourcePath("transfer_manager/go/tests/e2e/pg2mock/debezium/debezium_snapshot_arr/testdata/change_item_val.txt"))
+	canonizedDebeziumValArr, err := os.ReadFile(yatest.SourcePath("transfer_manager/go/tests/e2e/pg2mock/debezium/debezium_snapshot_arr/testdata/change_item_val.txt"))
 	require.NoError(t, err)
 	canonizedDebeziumVal := string(canonizedDebeziumValArr)
 

--- a/tests/e2e/ydb2mock/debezium/debezium_snapshot/check_db_test.go
+++ b/tests/e2e/ydb2mock/debezium/debezium_snapshot/check_db_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -34,9 +33,9 @@ func TestGroup(t *testing.T) {
 
 	//-----------------------------------------------------------------------------------------------------------------
 
-	canonizedDebeziumKeyArr, err := ioutil.ReadFile(yatest.SourcePath("transfer_manager/go/tests/e2e/ydb2mock/debezium/debezium_snapshot/testdata/change_item_key.txt"))
+	canonizedDebeziumKeyArr, err := os.ReadFile(yatest.SourcePath("transfer_manager/go/tests/e2e/ydb2mock/debezium/debezium_snapshot/testdata/change_item_key.txt"))
 	require.NoError(t, err)
-	canonizedDebeziumValArr, err := ioutil.ReadFile(yatest.SourcePath("transfer_manager/go/tests/e2e/ydb2mock/debezium/debezium_snapshot/testdata/change_item_val.txt"))
+	canonizedDebeziumValArr, err := os.ReadFile(yatest.SourcePath("transfer_manager/go/tests/e2e/ydb2mock/debezium/debezium_snapshot/testdata/change_item_val.txt"))
 	require.NoError(t, err)
 	canonizedDebeziumVal := string(canonizedDebeziumValArr)
 


### PR DESCRIPTION
Replace some deprecated code.

Some where left as-is as there were possible breaking changes that need to be further investigated. Those include protobuf libs and bson.