### PR TITLE
Add port-logging for failed CH version resolver

### DIFF
--- a/pkg/providers/clickhouse/model/model_storage_params.go
+++ b/pkg/providers/clickhouse/model/model_storage_params.go
@@ -123,5 +123,5 @@ func (c *ChStorageParams) ToConnParams() connConfigWrapper {
 }
 
 func (c *ChStorageParams) String() string {
-	return fmt.Sprintf("%s:[%v|%v]/%v", c.Shards, c.NativePort, c.HTTPPort, c.Database)
+	return fmt.Sprintf("%v:[%v|%v]/%v", c.Shards, c.NativePort, c.HTTPPort, c.Database)
 }

--- a/pkg/providers/clickhouse/model/model_storage_params.go
+++ b/pkg/providers/clickhouse/model/model_storage_params.go
@@ -1,5 +1,7 @@
 package model
 
+import "fmt"
+
 // ---
 // ch
 
@@ -118,4 +120,8 @@ func (w connConfigWrapper) PemFileContent() string {
 
 func (c *ChStorageParams) ToConnParams() connConfigWrapper {
 	return connConfigWrapper{p: c}
+}
+
+func (c *ChStorageParams) String() string {
+	return fmt.Sprintf("%s:[%v|%v]/%v", c.Shards, c.NativePort, c.HTTPPort, c.Database)
 }

--- a/pkg/providers/clickhouse/storage.go
+++ b/pkg/providers/clickhouse/storage.go
@@ -903,7 +903,7 @@ func NewStorage(config *model.ChStorageParams, transfer *dp_model.Transfer, opts
 			if errors.IsFatalClickhouseError(err) {
 				return "", backoff.Permanent(xerrors.Errorf("unable to select clickhouse version: %w", err))
 			}
-			return "", xerrors.Errorf("unable to select clickhouse: %s: version: %w", config.String(), err)
+			return "", xerrors.Errorf("unable to select clickhouse %s version: %w", config.String(), err)
 		}
 		return version, nil
 	}, backoff.NewExponentialBackOff(), util.BackoffLoggerWarn(logger.Log, "version resolver"))

--- a/pkg/providers/clickhouse/storage.go
+++ b/pkg/providers/clickhouse/storage.go
@@ -903,7 +903,7 @@ func NewStorage(config *model.ChStorageParams, transfer *dp_model.Transfer, opts
 			if errors.IsFatalClickhouseError(err) {
 				return "", backoff.Permanent(xerrors.Errorf("unable to select clickhouse version: %w", err))
 			}
-			return "", xerrors.Errorf("unable to select clickhouse version: %w", err)
+			return "", xerrors.Errorf("unable to select clickhouse: %s version: %w", config.String(), err)
 		}
 		return version, nil
 	}, backoff.NewExponentialBackOff(), util.BackoffLoggerWarn(logger.Log, "version resolver"))

--- a/pkg/providers/clickhouse/storage.go
+++ b/pkg/providers/clickhouse/storage.go
@@ -903,7 +903,7 @@ func NewStorage(config *model.ChStorageParams, transfer *dp_model.Transfer, opts
 			if errors.IsFatalClickhouseError(err) {
 				return "", backoff.Permanent(xerrors.Errorf("unable to select clickhouse version: %w", err))
 			}
-			return "", xerrors.Errorf("unable to select clickhouse: %s version: %w", config.String(), err)
+			return "", xerrors.Errorf("unable to select clickhouse: %s: version: %w", config.String(), err)
 		}
 		return version, nil
 	}, backoff.NewExponentialBackOff(), util.BackoffLoggerWarn(logger.Log, "version resolver"))


### PR DESCRIPTION
Related to https://github.com/doublecloud/transfer/issues/186