### PR TITLE
Slight improve on numeric parser perf

### DIFF
--- a/pkg/parsers/generic/generic_parser.go
+++ b/pkg/parsers/generic/generic_parser.go
@@ -623,7 +623,8 @@ func wrapIntoEmptyInterface(v *fastjson.Value, useNumbers bool) interface{} {
 		return v.GetBool()
 	case fastjson.TypeNumber:
 		if useNumbers {
-			return json.Number(v.MarshalTo(nil))
+			// v.String do wierd magic trick that prevent escape string to heap
+			return json.Number(v.String())
 		}
 		return v.GetFloat64()
 	default:


### PR DESCRIPTION
Befor:
```
BenchmarkNumberType/no-num
BenchmarkNumberType/no-num-10         	  332910	      3478 ns/op	  69.87 MB/s	    3162 B/op	      45 allocs/op
BenchmarkNumberType/num
BenchmarkNumberType/num-10            	  313408	      3839 ns/op	  63.29 MB/s	    3555 B/op	      64 allocs/op
```

After
```
BenchmarkNumberType/no-num
BenchmarkNumberType/no-num-10         	  345669	      3483 ns/op	  69.78 MB/s	    3162 B/op	      45 allocs/op
BenchmarkNumberType/num
BenchmarkNumberType/num-10            	  328444	      3728 ns/op	  65.18 MB/s	    3426 B/op	      57 allocs/op
```