### PR TITLE
Speedup debezium parse

### DIFF
--- a/pkg/debezium/pg/emitter.go
+++ b/pkg/debezium/pg/emitter.go
@@ -1,7 +1,6 @@
 package pg
 
 import (
-	"encoding/json"
 	"math"
 	"strconv"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	"github.com/doublecloud/transfer/pkg/debezium/typeutil"
 	"github.com/doublecloud/transfer/pkg/providers/postgres"
 	"github.com/doublecloud/transfer/pkg/util"
+	"github.com/goccy/go-json"
 	"github.com/jackc/pgtype"
 )
 

--- a/pkg/debezium/pg/tests/receiver_bench_test.go
+++ b/pkg/debezium/pg/tests/receiver_bench_test.go
@@ -14,6 +14,23 @@ import (
 
 func BenchmarkReceiverTest(b *testing.B) {
 	b.Run("parse", func(b *testing.B) {
+		b.Run("citext", func(b *testing.B) {
+			canonDebeziumMsgWithoutSequence := wipeSequenceAndIncremental(debeziumMsg25)
+			receiver := debezium.NewReceiver(map[abstract.TableID]map[string]*debeziumcommon.OriginalTypeInfo{
+				{Namespace: "public", Name: "basic_types"}: {
+					"id":  {OriginalType: "pg:integer"},
+					"val": {OriginalType: `pg:citext`},
+				},
+			}, nil)
+
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				co, err := receiver.Receive(canonDebeziumMsgWithoutSequence)
+				require.NoError(b, err)
+				b.SetBytes(int64(co.Size.Read))
+			}
+			b.ReportAllocs()
+		})
 		b.Run("tz", func(b *testing.B) {
 			canonDebeziumMsgWithoutSequence := wipeSequenceAndIncremental(debeziumMsg30)
 			receiver := debezium.NewReceiver(map[abstract.TableID]map[string]*debeziumcommon.OriginalTypeInfo{
@@ -27,7 +44,7 @@ func BenchmarkReceiverTest(b *testing.B) {
 			for n := 0; n < b.N; n++ {
 				co, err := receiver.Receive(canonDebeziumMsgWithoutSequence)
 				require.NoError(b, err)
-				b.SetBytes(int64(co.Size.Values))
+				b.SetBytes(int64(co.Size.Read))
 			}
 			b.ReportAllocs()
 		})
@@ -44,7 +61,7 @@ func BenchmarkReceiverTest(b *testing.B) {
 			for n := 0; n < b.N; n++ {
 				co, err := receiver.Receive(canonDebeziumMsgWithoutSequence)
 				require.NoError(b, err)
-				b.SetBytes(int64(co.Size.Values))
+				b.SetBytes(int64(co.Size.Read))
 			}
 			b.ReportAllocs()
 		})

--- a/pkg/debezium/receiver.go
+++ b/pkg/debezium/receiver.go
@@ -199,6 +199,10 @@ func (r *Receiver) receive(schema, payload []byte) (*abstract.ChangeItem, error)
 		Query: "",
 		Size:  abstract.RawEventSize(util.DeepSizeof(payload)),
 	}
+	if kind != abstract.DeleteKind {
+		result.ColumnNames = make([]string, 0, len(currDebeziumSchema.Fields))
+		result.ColumnValues = make([]interface{}, 0, len(currDebeziumSchema.Fields))
+	}
 	for i := range currDebeziumSchema.Fields {
 		if val, ok := currValuesMap[currDebeziumSchema.Fields[i].Field]; ok {
 			originalType := r.originalType(payloadStruct.Source.Schema, payloadStruct.Source.Table, currDebeziumSchema.Fields[i].Field)

--- a/pkg/debezium/unpacker/include_schema.go
+++ b/pkg/debezium/unpacker/include_schema.go
@@ -1,10 +1,9 @@
 package unpacker
 
 import (
-	"encoding/json"
-
 	"github.com/doublecloud/transfer/library/go/core/xerrors"
 	"github.com/doublecloud/transfer/pkg/util"
+	"github.com/goccy/go-json"
 )
 
 type IncludeSchema struct {

--- a/pkg/providers/postgres/wal2json_parser.go
+++ b/pkg/providers/postgres/wal2json_parser.go
@@ -1,9 +1,10 @@
 package postgres
 
 import (
-	"encoding/json"
 	"sync"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/doublecloud/transfer/library/go/core/xerrors"
 	"github.com/doublecloud/transfer/pkg/util"

--- a/pkg/util/jsonx/default_decoder.go
+++ b/pkg/util/jsonx/default_decoder.go
@@ -2,8 +2,9 @@ package jsonx
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
+
+	"github.com/goccy/go-json"
 )
 
 // NewDefaultDecoder constructs a default JSON decoder for Data Transfer.

--- a/pkg/util/jsonx/traverse.go
+++ b/pkg/util/jsonx/traverse.go
@@ -1,7 +1,7 @@
 package jsonx
 
 import (
-	"encoding/json"
+	"github.com/goccy/go-json"
 
 	"github.com/doublecloud/transfer/library/go/core/xerrors"
 )

--- a/pkg/util/jsonx/value_decoder.go
+++ b/pkg/util/jsonx/value_decoder.go
@@ -1,7 +1,7 @@
 package jsonx
 
 import (
-	"encoding/json"
+	"github.com/goccy/go-json"
 
 	"github.com/doublecloud/transfer/library/go/core/xerrors"
 )


### PR DESCRIPTION
Before:
```
BenchmarkReceiverTest
BenchmarkReceiverTest/parse
BenchmarkReceiverTest/parse/tz
BenchmarkReceiverTest/parse/tz-10      	   53989	     22082 ns/op	  15.58 MB/s	    9008 B/op	      55 allocs/op
BenchmarkReceiverTest/parse/no-tz
BenchmarkReceiverTest/parse/no-tz-10   	   54669	     21947 ns/op	  15.67 MB/s	    9007 B/op	      55 allocs/op
PASS
```

After
```
BenchmarkReceiverTest
BenchmarkReceiverTest/parse
BenchmarkReceiverTest/parse/citext
BenchmarkReceiverTest/parse/citext-10  	  134011	      8474 ns/op	  39.30 MB/s	   12149 B/op	      36 allocs/op
BenchmarkReceiverTest/parse/tz
BenchmarkReceiverTest/parse/tz-10      	  130683	      9110 ns/op	  37.76 MB/s	   12679 B/op	      36 allocs/op
BenchmarkReceiverTest/parse/no-tz
BenchmarkReceiverTest/parse/no-tz-10   	  135462	      8913 ns/op	  38.60 MB/s	   12679 B/op	      36 allocs/op
```

Main gain from faster json parse, total gain x3