### PR TITLE
MySQL DBLog implementation

### DIFF
--- a/pkg/providers/mysql/cast.go
+++ b/pkg/providers/mysql/cast.go
@@ -194,3 +194,7 @@ func typeToYt(dataType string, rawColumnType string) schema.Type {
 		return schema.TypeBytes
 	}
 }
+
+func Represent(val interface{}, colSchema abstract.ColSchema) (string, error) {
+	return CastToMySQL(val, colSchema), nil
+}

--- a/pkg/providers/mysql/dblog/signal_table.go
+++ b/pkg/providers/mysql/dblog/signal_table.go
@@ -1,0 +1,276 @@
+package dblog
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/doublecloud/transfer/library/go/core/xerrors"
+	"github.com/doublecloud/transfer/pkg/abstract"
+	"github.com/doublecloud/transfer/pkg/dblog"
+	"github.com/doublecloud/transfer/pkg/util"
+	"github.com/google/uuid"
+	"go.ytsaurus.tech/library/go/core/log"
+)
+
+type (
+	txOp func(conn *sql.Tx) error
+)
+
+const (
+	SignalTableName = "__data_transfer_signal_table"
+)
+
+type signalTable struct {
+	logger     log.Logger
+	transferID string
+	schemaName string
+	db         *sql.DB
+}
+
+func buildSignalTableDDL(schemaName string) string {
+	query := `CREATE TABLE IF NOT EXISTS %s.%s
+			  (
+				  table_schema VARCHAR(255),
+				  table_name VARCHAR(255),
+				  transfer_id VARCHAR(255),
+				  mark CHAR(36),
+				  mark_type CHAR(1),
+				  low_bound TEXT,
+				  PRIMARY KEY (table_schema, table_name, transfer_id, mark_type)
+			  );`
+
+	return fmt.Sprintf(query, schemaName, SignalTableName)
+}
+
+func (s *signalTable) makeWatermarkQuery() string {
+	query := `INSERT INTO %s.%s (table_schema, table_name, transfer_id, mark, mark_type, low_bound)
+			  VALUES (?, ?, ?, ?, ?, ?)
+			  ON DUPLICATE KEY UPDATE
+			  mark = VALUES(mark),
+			  low_bound = VALUES(low_bound);`
+
+	return fmt.Sprintf(query, s.schemaName, SignalTableName)
+}
+
+func (s *signalTable) resolveLowBoundQuery() string {
+	query := `SELECT low_bound FROM %s.%s
+	          WHERE table_schema = ?
+	          AND table_name = ?
+	          AND transfer_id = ?
+	          AND mark_type = ?;`
+
+	return fmt.Sprintf(query, s.schemaName, SignalTableName)
+}
+
+func deleteWatermarksQuery(schemaName string) string {
+	query := `DELETE FROM %s.%s WHERE transfer_id = ?;`
+	return fmt.Sprintf(query, schemaName, SignalTableName)
+}
+
+func signalTableExist(ctx context.Context, conn *sql.DB, schemaName string) (bool, error) {
+	query := `SELECT EXISTS (
+		SELECT 1 
+		FROM information_schema.tables 
+		WHERE table_schema = ? 
+		AND table_name = ?
+	   );`
+
+	var exist bool
+	if err := conn.QueryRowContext(ctx, query, schemaName, SignalTableName).Scan(&exist); err != nil {
+		return false, err
+	}
+
+	return exist, nil
+}
+
+func NewSignalTable(
+	ctx context.Context,
+	db *sql.DB,
+	logger log.Logger,
+	transferID string,
+	schemaName string,
+) (*signalTable, error) {
+	tbl := &signalTable{
+		db:         db,
+		logger:     logger,
+		transferID: transferID,
+		schemaName: schemaName,
+	}
+
+	if err := tbl.init(ctx); err != nil {
+		return nil, xerrors.Errorf("unable to initialize signal table: %w", err)
+	}
+
+	return tbl, nil
+}
+
+func (s *signalTable) init(ctx context.Context) error {
+	return s.tx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, buildSignalTableDDL(s.schemaName)); err != nil {
+			return xerrors.Errorf("failed to ensure existence of the signal table service table: %w", err)
+		}
+		return nil
+	})
+}
+
+func (s *signalTable) tx(ctx context.Context, operation txOp) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return xerrors.Errorf("unable to begin transaction: %w", err)
+	}
+
+	if err := operation(tx); err != nil {
+		if err := tx.Rollback(); err != nil {
+			s.logger.Warn("Unable to rollback", log.Error(err))
+		}
+		return xerrors.Errorf("unable to execute operation: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return xerrors.Errorf("unable to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+func (s *signalTable) CreateWatermark(
+	ctx context.Context,
+	tableID abstract.TableID,
+	watermarkType dblog.WatermarkType,
+	lowBoundArr []string,
+) (uuid.UUID, error) {
+	var newUUID uuid.UUID
+	err := s.tx(ctx, func(_ *sql.Tx) error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return xerrors.Errorf("unable to begin transaction: %w", err)
+		}
+
+		rollback := util.Rollbacks{}
+		defer rollback.Do()
+		rollback.Add(func() {
+			if err := tx.Rollback(); err != nil {
+				s.logger.Info("Unable to rollback", log.Error(err))
+			}
+		})
+
+		newUUID = uuid.New()
+
+		lowBoundStr, err := dblog.ConvertArrayToString(lowBoundArr)
+		if err != nil {
+			return xerrors.Errorf("unable to convert low bound array to string")
+		}
+
+		query := s.makeWatermarkQuery()
+		s.logger.Info(
+			fmt.Sprintf("CreateWatermark - query: %s", strings.ReplaceAll(query, "\n", "")),
+			log.String("tableID.Namespace", tableID.Namespace),
+			log.String("tableID.Name", tableID.Name),
+			log.String("s.transferID", s.transferID),
+			log.String("newUUID", newUUID.String()),
+			log.String("watermarkType", string(watermarkType)),
+			log.String("lowBoundStr", lowBoundStr),
+		)
+
+		_, err = tx.ExecContext(
+			ctx,
+			query,
+			tableID.Namespace,
+			tableID.Name,
+			s.transferID,
+			newUUID,
+			string(watermarkType),
+			lowBoundStr,
+		)
+		if err != nil {
+			return xerrors.Errorf("failed to create watermark for %s: %w", tableID.Fqtn(), err)
+		}
+
+		if err := tx.Commit(); err != nil {
+			return xerrors.Errorf("unable to commit transaction: %w", err)
+		}
+
+		rollback.Cancel()
+		return nil
+	})
+
+	return newUUID, err
+}
+
+func (s *signalTable) IsWatermark(item *abstract.ChangeItem, tableID abstract.TableID, markUUID uuid.UUID) (bool, dblog.WatermarkType) {
+	isWatermark := item.Table == SignalTableName
+	if !isWatermark {
+		return false, dblog.BadWatermarkType
+	}
+
+	row := item.AsMap()
+	if item.Kind == abstract.DeleteKind ||
+		row["table_schema"].(string) != tableID.Namespace ||
+		row["table_name"].(string) != tableID.Name ||
+		row["transfer_id"].(string) != s.transferID {
+		return false, dblog.BadWatermarkType
+	}
+
+	parsedUUID, err := uuid.Parse(row["mark"].(string))
+	if err != nil {
+		return true, dblog.BadWatermarkType
+	}
+
+	if parsedUUID != markUUID {
+		return true, dblog.BadWatermarkType
+	}
+
+	if _, ok := row["mark_type"].(string); !ok {
+		return false, dblog.BadWatermarkType
+	}
+	strVal := row["mark_type"].(string)
+	if len(strVal) != 1 {
+		return false, dblog.BadWatermarkType
+	}
+
+	return true, dblog.WatermarkType(strVal)
+}
+
+func (s *signalTable) resolveLowBound(ctx context.Context, tableID abstract.TableID) []string {
+	var lowBoundStr string
+
+	err := s.tx(ctx, func(conn *sql.Tx) error {
+		query := s.resolveLowBoundQuery()
+
+		err := conn.QueryRowContext(ctx, query, tableID.Namespace, tableID.Name, s.transferID, dblog.SuccessWatermarkType).Scan(&lowBoundStr)
+		if err != nil {
+			return xerrors.Errorf("failed to retrieve low_bound for Namespace: %s, Table: %s, transferID: %s, err : %w", tableID.Namespace, tableID.Name, s.transferID, err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil
+	}
+
+	lowBoundArray, err := dblog.ConvertStringToArray(lowBoundStr)
+	if err != nil {
+		return nil
+	}
+
+	return lowBoundArray
+}
+
+func DeleteWatermarks(ctx context.Context, db *sql.DB, schemaName string, transferID string) error {
+	signalTableExist, err := signalTableExist(ctx, db, schemaName)
+	if err != nil {
+		return xerrors.Errorf("signal table check query failed err: %w", err)
+	}
+	if signalTableExist {
+		query := deleteWatermarksQuery(schemaName)
+		_, err := db.ExecContext(ctx, query, transferID)
+		if err != nil {
+			return xerrors.Errorf("failed to delete watermarks err: %w", err)
+		}
+	}
+
+	return err
+}

--- a/pkg/providers/mysql/dblog/storage.go
+++ b/pkg/providers/mysql/dblog/storage.go
@@ -1,0 +1,155 @@
+package dblog
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/doublecloud/transfer/library/go/core/xerrors"
+	"github.com/doublecloud/transfer/pkg/abstract"
+	"github.com/doublecloud/transfer/pkg/dblog"
+	"github.com/doublecloud/transfer/pkg/dblog/tablequery"
+	"go.ytsaurus.tech/library/go/core/log"
+)
+
+type Storage struct {
+	logger log.Logger
+
+	source  abstract.Source
+	storage tablequery.StorageTableQueryable
+	db      *sql.DB
+
+	chunkSize uint64
+
+	transferID       string
+	represent        dblog.ChangeItemConverter
+	keeperSchema     string
+	betweenMarksOpts []func()
+}
+
+func NewStorage(
+	logger log.Logger,
+	src abstract.Source,
+	storage tablequery.StorageTableQueryable,
+	db *sql.DB,
+	chunkSize uint64,
+	transferID string,
+	keeperSchema string,
+	represent dblog.ChangeItemConverter,
+	betweenMarksOpts ...func(),
+) (abstract.Storage, error) {
+	return &Storage{
+		logger:           log.With(logger, log.Any("component", "dblog")),
+		source:           src,
+		storage:          storage,
+		db:               db,
+		chunkSize:        chunkSize,
+		transferID:       transferID,
+		keeperSchema:     keeperSchema,
+		represent:        represent,
+		betweenMarksOpts: betweenMarksOpts,
+	}, nil
+}
+
+func (s *Storage) Close() {
+	s.storage.Close()
+}
+
+func (s *Storage) Ping() error {
+	return s.storage.Ping()
+}
+
+func (s *Storage) LoadTable(ctx context.Context, tableDescr abstract.TableDescription, pusher abstract.Pusher) error {
+	pkColNames, err := dblog.ResolvePrimaryKeyColumns(ctx, s.storage, tableDescr.ID(), IsSupportedKeyType)
+	if err != nil {
+		return xerrors.Errorf("unable to get primary key: %w", err)
+	}
+
+	chunkSize := s.chunkSize
+
+	if chunkSize == 0 {
+		chunkSize, err = dblog.InferChunkSize(s.storage, tableDescr.ID(), dblog.DefaultChunkSizeInBytes)
+		if err != nil {
+			return xerrors.Errorf("unable to generate chunk size: %w", err)
+		}
+		s.logger.Infof("Storage::LoadTable - inferred chunkSize: %d", chunkSize)
+	} else {
+		s.logger.Infof("Storage::LoadTable - from config chunkSize: %d", chunkSize)
+	}
+
+	signalTable, err := NewSignalTable(ctx, s.db, s.logger, s.transferID, s.keeperSchema)
+	if err != nil {
+		return xerrors.Errorf("unable to create signal table: %w", err)
+	}
+
+	tableQuery := tablequery.NewTableQuery(tableDescr.ID(), true, "", 0, chunkSize)
+	s.logger.Infof("Storage::LoadTable - tableQuery: %v", tableQuery)
+	lowBound := signalTable.resolveLowBound(ctx, tableDescr.ID())
+	s.logger.Infof("Storage::LoadTable - lowBound: %v", lowBound)
+
+	iterator, err := dblog.NewIncrementalIterator(
+		s.logger,
+		s.storage,
+		tableQuery,
+		signalTable,
+		s.represent,
+		pkColNames,
+		lowBound,
+		chunkSize,
+		s.betweenMarksOpts...,
+	)
+	if err != nil {
+		return xerrors.Errorf("unable to build iterator, err: %w", err)
+	}
+
+	items, err := iterator.Next(ctx)
+	if err != nil {
+		return xerrors.Errorf("failed to do initial iteration: %w", err)
+	}
+
+	s.logger.Infof("Storage::LoadTable - first iteration done, extacted items: %d", len(items))
+
+	chunk, err := dblog.ResolveChunkMapFromArr(items, pkColNames, s.represent)
+	if err != nil {
+		return xerrors.Errorf("failed to resolve chunk: %w", err)
+	}
+
+	asyncSink := dblog.NewIncrementalAsyncSink(
+		ctx,
+		s.logger,
+		signalTable,
+		tableDescr.ID(),
+		iterator,
+		pkColNames,
+		chunk,
+		s.represent,
+		func() { s.source.Stop() },
+		pusher,
+	)
+
+	err = s.source.Run(asyncSink)
+	if err != nil {
+		return xerrors.Errorf("unable to run worker: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Storage) TableSchema(ctx context.Context, table abstract.TableID) (*abstract.TableSchema, error) {
+	return s.storage.TableSchema(ctx, table)
+}
+
+func (s *Storage) TableList(filter abstract.IncludeTableList) (abstract.TableMap, error) {
+	return s.storage.TableList(filter)
+}
+
+func (s *Storage) ExactTableRowsCount(table abstract.TableID) (uint64, error) {
+	return s.storage.ExactTableRowsCount(table)
+}
+
+func (s *Storage) EstimateTableRowsCount(table abstract.TableID) (uint64, error) {
+	return s.storage.EstimateTableRowsCount(table)
+}
+
+func (s *Storage) TableExists(table abstract.TableID) (bool, error) {
+	return s.storage.TableExists(table)
+}

--- a/pkg/providers/mysql/dblog/supported_key_type.go
+++ b/pkg/providers/mysql/dblog/supported_key_type.go
@@ -1,0 +1,59 @@
+package dblog
+
+import (
+	"strings"
+
+	"github.com/doublecloud/transfer/pkg/util/set"
+)
+
+var supportedTypesArr = []string{
+	"boolean",
+	"bit",
+
+	"tinyint",
+	"smallint",
+	"mediumint",
+	"int",
+	"integer",
+	"bigint",
+
+	"double",
+	"double precision",
+	"float",
+	"decimal",
+	"numeric",
+
+	"char",
+	"varchar",
+	"text",
+	"tinytext",
+	"mediumtext",
+	"longtext",
+
+	"binary",
+	"varbinary",
+	"blob",
+	"tinyblob",
+	"mediumblob",
+	"longblob",
+
+	"date",
+	"datetime",
+	"timestamp",
+	"time",
+	"year",
+
+	"json",
+
+	"uuid", // MySQL 8.0+
+
+	"set",
+	"enum",
+}
+
+var supportedTypes = set.New(supportedTypesArr...)
+
+func IsSupportedKeyType(keyType string) bool {
+	normalKeyType := strings.Split(keyType, "(")[0]
+	return supportedTypes.Contains(strings.TrimPrefix(normalKeyType, "mysql:"))
+}

--- a/pkg/providers/mysql/dblog/tests/basic/db_log_test.go
+++ b/pkg/providers/mysql/dblog/tests/basic/db_log_test.go
@@ -1,0 +1,123 @@
+package basic
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/doublecloud/transfer/internal/logger"
+	"github.com/doublecloud/transfer/internal/metrics"
+	"github.com/doublecloud/transfer/pkg/abstract"
+	"github.com/doublecloud/transfer/pkg/abstract/coordinator"
+	"github.com/doublecloud/transfer/pkg/providers/mysql"
+	"github.com/doublecloud/transfer/pkg/providers/mysql/dblog"
+	"github.com/doublecloud/transfer/pkg/providers/mysql/mysqlrecipe"
+	"github.com/doublecloud/transfer/tests/helpers"
+	"github.com/stretchr/testify/require"
+	ytschema "go.ytsaurus.tech/yt/go/schema"
+)
+
+var (
+	Source        = mysqlrecipe.RecipeMysqlSource()
+	Destination   = mysqlrecipe.RecipeMysqlTarget()
+	testTableName = "__test_num_table"
+
+	rowsAfterInserts = uint64(14)
+
+	incrementalLimit = uint64(10)
+	numberOfInserts  = 16
+
+	sleepBetweenInserts = 100 * time.Millisecond
+
+	minOutputItems = 15
+	maxOutputItems = 30
+)
+
+func init() {
+	_ = os.Setenv("YC", "1") // to not go to vanga
+	Source.WithDefaults()
+}
+
+func TestIncrementalSnapshot(t *testing.T) {
+	defer func() {
+		require.NoError(t, helpers.CheckConnections(
+			helpers.LabeledPort{Label: "PG source", Port: Source.Port},
+		))
+	}()
+	Destination.Database = Source.Database
+	sink, err := mysql.NewSinker(logger.Log, Destination, helpers.EmptyRegistry())
+	require.NoError(t, err)
+
+	arrColSchema := abstract.NewTableSchema([]abstract.ColSchema{
+		{ColumnName: "id", DataType: ytschema.TypeInt32.String(), PrimaryKey: true},
+		{ColumnName: "num", DataType: ytschema.TypeInt32.String(), PrimaryKey: false},
+	})
+	changeItemBuilder := helpers.NewChangeItemsBuilder(Source.Database, testTableName, arrColSchema)
+
+	require.NoError(t, sink.Push(changeItemBuilder.Inserts(t, []map[string]interface{}{{"id": 11, "num": 11}, {"id": 12, "num": 12}, {"id": 13, "num": 13}, {"id": 14, "num": 14}})))
+
+	helpers.CheckRowsCount(t, Source, Source.Database, testTableName, rowsAfterInserts)
+
+	mysqlStorage, err := mysql.NewStorage(Source.ToStorageParams())
+	require.NoError(t, err)
+
+	cp := coordinator.NewStatefulFakeClient()
+	require.NoError(t, mysql.SyncBinlogPosition(Source, helpers.TransferID, cp))
+	src, err := mysql.NewSource(
+		Source,
+		helpers.TransferID,
+		nil,
+		logger.Log,
+		metrics.NewRegistry(),
+		cp,
+		false)
+	require.NoError(t, err)
+
+	storage, err := dblog.NewStorage(
+		logger.Log,
+		src,
+		mysqlStorage,
+		mysqlStorage.DB,
+		incrementalLimit,
+		helpers.TransferID,
+		Source.Database,
+		mysql.Represent,
+	)
+	require.NoError(t, err)
+
+	sourceTables, err := storage.TableList(nil)
+	require.NoError(t, err)
+
+	var numTable *abstract.TableDescription = nil
+	tables := sourceTables.ConvertToTableDescriptions()
+
+	for _, table := range tables {
+		if table.Name == testTableName {
+			numTable = &table
+		}
+	}
+
+	require.NotNil(t, numTable)
+
+	var output []abstract.ChangeItem
+
+	pusher := func(items []abstract.ChangeItem) error {
+		output = append(output, items...)
+
+		return nil
+	}
+
+	go func() {
+		for i := 0; i < numberOfInserts; i++ {
+			require.NoError(t, sink.Push(changeItemBuilder.Inserts(t, []map[string]interface{}{{"id": i, "num": i}})))
+			time.Sleep(sleepBetweenInserts)
+		}
+	}()
+
+	err = storage.LoadTable(context.Background(), *numTable, pusher)
+	require.NoError(t, err)
+
+	require.GreaterOrEqual(t, len(output), minOutputItems)
+	require.LessOrEqual(t, len(output), maxOutputItems)
+}

--- a/pkg/providers/mysql/dblog/tests/basic/dump/source.sql
+++ b/pkg/providers/mysql/dblog/tests/basic/dump/source.sql
@@ -1,0 +1,7 @@
+CREATE TABLE __test_num_table (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    num INT
+);
+
+INSERT INTO __test_num_table (num) VALUES
+    (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);

--- a/pkg/providers/mysql/model_source.go
+++ b/pkg/providers/mysql/model_source.go
@@ -52,6 +52,8 @@ type MysqlSource struct {
 	PlzNoHomo    bool                // forcefully disable homo features, mostly for tests
 	RootCAFiles  []string
 	ConnectionID string
+
+	DBLogEnabled bool // force DBLog snapshot instead of common
 }
 
 var _ model.Source = (*MysqlSource)(nil)

--- a/pkg/providers/mysql/provider.go
+++ b/pkg/providers/mysql/provider.go
@@ -3,8 +3,8 @@ package mysql
 import (
 	"context"
 	"encoding/gob"
-
 	"github.com/cenkalti/backoff/v4"
+	"github.com/doublecloud/transfer/internal/logger"
 	"github.com/doublecloud/transfer/library/go/core/metrics"
 	"github.com/doublecloud/transfer/library/go/core/metrics/solomon"
 	"github.com/doublecloud/transfer/library/go/core/xerrors"
@@ -14,6 +14,8 @@ import (
 	debeziumparameters "github.com/doublecloud/transfer/pkg/debezium/parameters"
 	"github.com/doublecloud/transfer/pkg/middlewares"
 	"github.com/doublecloud/transfer/pkg/providers"
+	"github.com/doublecloud/transfer/pkg/providers/mysql/dblog"
+	abstract_sink "github.com/doublecloud/transfer/pkg/sink"
 	"go.ytsaurus.tech/library/go/core/log"
 )
 
@@ -232,8 +234,15 @@ func (p *Provider) Activate(ctx context.Context, task *model.TransferOperation, 
 		if err := callbacks.CheckIncludes(tables); err != nil {
 			return xerrors.Errorf("Failed in accordance with configuration: %w", err)
 		}
-		if err := callbacks.Upload(tables); err != nil {
-			return xerrors.Errorf("Snapshot loading failed: %w", err)
+		if src.DBLogEnabled {
+			logger.Log.Info("DBLog enabled")
+			if err := p.DBLogUpload(ctx, tables); err != nil {
+				return xerrors.Errorf("DBLog snapshot loading failed: %w", err)
+			}
+		} else {
+			if err := callbacks.Upload(tables); err != nil {
+				return xerrors.Errorf("Snapshot loading failed: %w", err)
+			}
 		}
 		if p.transfer.SnapshotOnly() {
 			if err := LoadMysqlSchema(p.transfer, registry, true); err != nil {
@@ -277,6 +286,68 @@ func (p *Provider) Update(ctx context.Context, addedTables []abstract.TableDescr
 
 func (p *Provider) Type() abstract.ProviderType {
 	return ProviderType
+}
+
+func (p *Provider) DBLogUpload(ctx context.Context, tables abstract.TableMap) error {
+	src, ok := p.transfer.Src.(*MysqlSource)
+	if !ok {
+		return xerrors.Errorf("unexpected type: %T", p.transfer.Src)
+	}
+	storage, err := NewStorage(src.ToStorageParams())
+	if err != nil {
+		return xerrors.Errorf("failed to create postgres storage: %w", err)
+	}
+
+	// ensure SignalTable exists
+	_, err = dblog.NewSignalTable(ctx, storage.DB, logger.Log, p.transfer.ID, src.Database)
+	if err != nil {
+		return xerrors.Errorf("unable to create signal table: %w", err)
+	}
+	// delete previous watermarks
+	if err := dblog.DeleteWatermarks(ctx, storage.DB, src.Database, p.transfer.ID); err != nil {
+		return xerrors.Errorf("unable to delete watermarks: %w", err)
+	}
+
+	sourceWrapper, err := p.Source()
+	if err != nil {
+		return xerrors.Errorf("failed to create source wrapper: %w", err)
+	}
+
+	dblogStorage, err := dblog.NewStorage(p.logger, sourceWrapper, storage, storage.DB, 10*1024, p.transfer.ID, src.Database, Represent)
+	if err != nil {
+		return xerrors.Errorf("failed to create DBLog storage: %w", err)
+	}
+
+	tableDescs := tables.ConvertToTableDescriptions()
+	for _, table := range tableDescs {
+		asyncSink, err := abstract_sink.MakeAsyncSink(
+			p.transfer,
+			logger.Log,
+			p.registry,
+			p.cp,
+			middlewares.MakeConfig(middlewares.WithEnableRetries),
+		)
+
+		pusher := abstract.PusherFromAsyncSink(asyncSink)
+
+		if err != nil {
+			return xerrors.Errorf("failed to make async sink: %w", err)
+		}
+
+		if err = backoff.Retry(func() error {
+			logger.Log.Infof("Starting upload table: %s", table.String())
+
+			err := dblogStorage.LoadTable(ctx, table, pusher)
+			if err == nil {
+				logger.Log.Infof("Upload table %s successfully", table.String())
+			}
+			return err
+		}, backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 10)); err != nil {
+			return xerrors.Errorf("failed to load table: %w", err)
+		}
+	}
+
+	return nil
 }
 
 func New(lgr log.Logger, registry metrics.Registry, cp coordinator.Coordinator, transfer *model.Transfer) providers.Provider {

--- a/pkg/providers/mysql/storage_dblog.go
+++ b/pkg/providers/mysql/storage_dblog.go
@@ -1,0 +1,108 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/dustin/go-humanize"
+
+	"github.com/doublecloud/transfer/internal/logger"
+	"github.com/doublecloud/transfer/library/go/core/xerrors"
+	"github.com/doublecloud/transfer/pkg/abstract"
+	"github.com/doublecloud/transfer/pkg/dblog/tablequery"
+	"github.com/doublecloud/transfer/pkg/util"
+	"go.ytsaurus.tech/library/go/core/log"
+)
+
+func (s *Storage) LoadQueryTable(ctx context.Context, tableQuery tablequery.TableQuery, pusher abstract.Pusher) error {
+	table := abstract.TableDescription{
+		Name:   tableQuery.TableID.Name,
+		Schema: tableQuery.TableID.Namespace,
+		EtaRow: 0,
+		Filter: tableQuery.Filter,
+		Offset: tableQuery.Offset,
+	}
+	st := util.GetTimestampFromContextOrNow(ctx)
+
+	pos, err := s.Position(ctx)
+	if err != nil {
+		return xerrors.Errorf("unable to read log position: %w", err)
+	}
+
+	tx, rollbacks, err := s.getSnapshotQueryable(ctx)
+	if err != nil {
+		return xerrors.Errorf("Can't get table read transaction: %w", err)
+	}
+	defer rollbacks.Do()
+
+	currTableSchema := s.fqtnSchema[table.ID()]
+
+	querySelect := buildSelectQuery(table, currTableSchema.Columns())
+
+	logger.Log.Infof("Storage::LoadQueryTable - built query: %s", querySelect)
+	logger.Log.Info("Storage read table", log.String("table", table.Fqtn()), log.String("query", querySelect))
+
+	if _, err := tx.ExecContext(ctx, "set net_read_timeout=3600;"); err != nil {
+		return xerrors.Errorf("Unable to set net_read_timeout=3600: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, "set net_write_timeout=3600;"); err != nil {
+		return xerrors.Errorf("Unable to set net_write_timeout=3600: %w", err)
+	}
+	timezone := timezoneOffset(s.ConnectionParams.Location)
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("set time_zone = '%s';", timezone)); err != nil {
+		return xerrors.Errorf("unable to set session timezone %s: %w", timezone, err)
+	}
+
+	tableRowsCount, tableDataSizeInBytes, err := getTableRowsCountTableDataSizeInBytes(ctx, tx, table)
+	if err != nil {
+		return xerrors.Errorf("Unable to get table %v size: %w", table.Fqtn(), err)
+	}
+
+	chunkSize := calcChunkSize(tableRowsCount, tableDataSizeInBytes, 100000)
+
+	logger.Log.Infof("Table %v: total rows %v, size %v in chunks by %v", table.Fqtn(), tableRowsCount, humanize.BigBytes(big.NewInt(int64(tableDataSizeInBytes))), chunkSize)
+
+	if table.Offset == 0 && table.Filter == "" && s.preSteps.Tables && s.IsHomo {
+		if err := pushCreateTable(ctx, tx, table.ID(), st, pusher); err != nil {
+			return xerrors.Errorf("Unable to push drop and create table %v DDL: %w", table.Fqtn(), err)
+		}
+	}
+
+	colNameToColTypeName, err := makeMapColNameToColTypeName(ctx, tx, table.Name)
+	if err != nil {
+		return xerrors.Errorf("unable to get column types: %w", err)
+	}
+
+	rows, err := tx.QueryContext(ctx, querySelect)
+	if err != nil {
+		logger.Log.Error("rows select error", log.Error(err))
+		return xerrors.Errorf("Unable to select data from table %v: %w", table.Fqtn(), err)
+	}
+	defer rows.Close()
+
+	err = readRowsAndPushByChunks(
+		s.ConnectionParams.Location,
+		rows,
+		st,
+		table,
+		currTableSchema,
+		colNameToColTypeName,
+		chunkSize,
+		pos.LSN,
+		s.IsHomo,
+		pusher,
+	)
+	if err != nil {
+		return xerrors.Errorf("unable to read rows and push by chunks: %w", err)
+	}
+
+	err = rows.Err()
+	if err != nil {
+		msg := "Unable to read rows"
+		logger.Log.Warn(msg, log.Error(err))
+		return xerrors.Errorf("%v: %w", msg, err)
+	}
+	logger.Log.Info("Done read rows")
+	return nil
+}


### PR DESCRIPTION
As referenced implementation took postgres
Add simple e2e test for db-log.
Add represent function to convert value to string. Mysql generate inconsistent schema (in terms of col-order), so replaced index-based col selection to a map

Closes: https://github.com/doublecloud/transfer/issues/171