### PR TITLE
Use yaml.v3 to properly parse time.Duration strings

### DIFF
--- a/pkg/instanceutil/metadata_service.go
+++ b/pkg/instanceutil/metadata_service.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/doublecloud/transfer/library/go/core/xerrors"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const InstanceMetadataAddr = "169.254.169.254"

--- a/recipe/mongo/pkg/config/config.go
+++ b/recipe/mongo/pkg/config/config.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 
 	"github.com/doublecloud/transfer/library/go/core/xerrors"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (


### PR DESCRIPTION
`yaml.v3` supports unmarshaling duration strings (e.g. `10s`) into `time.Duration` fields.

Closes #213  