### PR TITLE
Add support for deletion tracking in ClickHouse sink tables

### DIFF
--- a/pkg/providers/clickhouse/model/model_ch_destination.go
+++ b/pkg/providers/clickhouse/model/model_ch_destination.go
@@ -62,6 +62,7 @@ type ChDestination struct {
 	SystemColumnsFirst      bool
 	IsUpdateable            bool
 	UpsertAbsentToastedRows bool
+	IsDeleteable            bool
 
 	// Insert settings
 	InsertParams InsertParams
@@ -228,6 +229,7 @@ func (d *ChDestination) ToReplicationFromPGSinkParams() ChDestinationWrapper {
 func (d *ChDestination) FillDependentFields(transfer *model.Transfer) {
 	if !model.IsAppendOnlySource(transfer.Src) && !transfer.SnapshotOnly() {
 		d.IsUpdateable = true
+		d.IsDeleteable = true
 		if d.ShardCol != "" {
 			d.ShardCol = ""
 			logger.Log.Warn("turned off sharding on ch-dst, sharding is allowed only for queue-src")
@@ -432,4 +434,8 @@ func (d ChDestinationWrapper) SetShards(shards map[string][]string) {
 			Hosts: hosts,
 		})
 	}
+}
+
+func (d ChDestinationWrapper) IsDeleteable() bool {
+	return d.Model.IsDeleteable
 }

--- a/pkg/providers/clickhouse/model/model_ch_destination.go
+++ b/pkg/providers/clickhouse/model/model_ch_destination.go
@@ -229,7 +229,6 @@ func (d *ChDestination) ToReplicationFromPGSinkParams() ChDestinationWrapper {
 func (d *ChDestination) FillDependentFields(transfer *model.Transfer) {
 	if !model.IsAppendOnlySource(transfer.Src) && !transfer.SnapshotOnly() {
 		d.IsUpdateable = true
-		d.IsDeleteable = true
 		if d.ShardCol != "" {
 			d.ShardCol = ""
 			logger.Log.Warn("turned off sharding on ch-dst, sharding is allowed only for queue-src")

--- a/pkg/providers/clickhouse/model/model_ch_source.go
+++ b/pkg/providers/clickhouse/model/model_ch_source.go
@@ -351,13 +351,3 @@ func (s ChSourceWrapper) SetShards(shards map[string][]string) {
 func (s ChSourceWrapper) IsDeleteable() bool {
 	return s.Model.IsDeleteable
 }
-
-func (s *ChSource) ToSinkParams() ChSourceWrapper {
-	copyChSource := *s
-	copyChSource.IsDeleteable = false // По умолчанию false для source
-	return ChSourceWrapper{
-		Model:    &copyChSource,
-		host:     "",
-		altHosts: nil,
-	}
-}

--- a/pkg/providers/clickhouse/model/model_ch_source.go
+++ b/pkg/providers/clickhouse/model/model_ch_source.go
@@ -53,6 +53,7 @@ type ChSource struct {
 	BufferSize       uint64
 	IOHomoFormat     ClickhouseIOFormat // one of - https://clickhouse.com/docs/en/interfaces/formats
 	RootCACertPaths  []string
+	IsDeleteable     bool
 }
 
 func (s *ChSource) Describe() model.Doc {
@@ -344,5 +345,19 @@ func (s ChSourceWrapper) SetShards(shards map[string][]string) {
 			Name:  shardName,
 			Hosts: hosts,
 		})
+	}
+}
+
+func (s ChSourceWrapper) IsDeleteable() bool {
+	return s.Model.IsDeleteable
+}
+
+func (s *ChSource) ToSinkParams() ChSourceWrapper {
+	copyChSource := *s
+	copyChSource.IsDeleteable = false // По умолчанию false для source
+	return ChSourceWrapper{
+		Model:    &copyChSource,
+		host:     "",
+		altHosts: nil,
 	}
 }

--- a/pkg/providers/clickhouse/model/model_sink_params.go
+++ b/pkg/providers/clickhouse/model/model_sink_params.go
@@ -47,7 +47,12 @@ type ChSinkServerParams interface {
 	//     1) ReplacingMergeTree engine family
 	//     2) table contains data-transfer system columns: '__data_transfer_commit_time', '__data_transfer_delete_time'
 	IsUpdateable() bool
-
+	// IsDeleteable
+	// automatically derived from transfer options.
+	// Deleteable - data-transfer term, means the table satisfies two conditions:
+	//     1) table contains data-transfer system column: '__data_transfer_is_deleted'
+	//     2) ReplacingMergeTree engine has arguments: '__data_transfer_is_deleted'
+	IsDeleteable() bool
 	// UpsertAbsentToastedRows When batch push fails on TOAST, interpret as sequential independent upserts.
 	// Useful in cases:
 	//  1. YDB Source with 'Updates' changefeed mode

--- a/pkg/providers/clickhouse/sink_table.go
+++ b/pkg/providers/clickhouse/sink_table.go
@@ -133,6 +133,7 @@ func (t *sinkTable) generateDDL(cols []abstract.ColSchema, distributed bool) str
 	if t.config.IsUpdateable() {
 		columnDefinitions = append(columnDefinitions, "`__data_transfer_commit_time` UInt64")
 		columnDefinitions = append(columnDefinitions, "`__data_transfer_delete_time` UInt64")
+		columnDefinitions = append(columnDefinitions, "`__data_transfer_is_deleted` UInt8 GENERATED ALWAYS AS (if(isNotEmpty(`__data_transfer_delete_time`), 1, 0))")
 	}
 	_, _ = result.WriteString(fmt.Sprintf(" (%s)", strings.Join(columnDefinitions, ", ")))
 
@@ -141,6 +142,9 @@ func (t *sinkTable) generateDDL(cols []abstract.ColSchema, distributed bool) str
 	if t.config.IsUpdateable() {
 		engine = fmt.Sprintf("Replacing%s", engine)
 		engineArgs = append(engineArgs, "__data_transfer_commit_time")
+		if t.config.IsDeleteable() {
+			engineArgs = append(engineArgs, "__data_transfer_is_deleted")
+		}
 	}
 	if distributed {
 		engine = fmt.Sprintf("Replicated%s", engine)

--- a/pkg/providers/clickhouse/sink_table.go
+++ b/pkg/providers/clickhouse/sink_table.go
@@ -133,7 +133,7 @@ func (t *sinkTable) generateDDL(cols []abstract.ColSchema, distributed bool) str
 	if t.config.IsUpdateable() {
 		columnDefinitions = append(columnDefinitions, "`__data_transfer_commit_time` UInt64")
 		columnDefinitions = append(columnDefinitions, "`__data_transfer_delete_time` UInt64")
-		columnDefinitions = append(columnDefinitions, "`__data_transfer_is_deleted` UInt8 GENERATED ALWAYS AS (if(isNotEmpty(`__data_transfer_delete_time`), 1, 0))")
+		columnDefinitions = append(columnDefinitions, "`__data_transfer_is_deleted` UInt8 MATERIALIZED (if(__data_transfer_delete_time != 0, 1, 0))")
 	}
 	_, _ = result.WriteString(fmt.Sprintf(" (%s)", strings.Join(columnDefinitions, ", ")))
 

--- a/pkg/providers/clickhouse/sink_table.go
+++ b/pkg/providers/clickhouse/sink_table.go
@@ -133,7 +133,9 @@ func (t *sinkTable) generateDDL(cols []abstract.ColSchema, distributed bool) str
 	if t.config.IsUpdateable() {
 		columnDefinitions = append(columnDefinitions, "`__data_transfer_commit_time` UInt64")
 		columnDefinitions = append(columnDefinitions, "`__data_transfer_delete_time` UInt64")
-		columnDefinitions = append(columnDefinitions, "`__data_transfer_is_deleted` UInt8 MATERIALIZED (if(__data_transfer_delete_time != 0, 1, 0))")
+		if t.config.IsDeleteable() {
+			columnDefinitions = append(columnDefinitions, "`__data_transfer_is_deleted` UInt8 MATERIALIZED (if(__data_transfer_delete_time != 0, 1, 0))")
+		}
 	}
 	_, _ = result.WriteString(fmt.Sprintf(" (%s)", strings.Join(columnDefinitions, ", ")))
 

--- a/tests/e2e/pg2ch/replication/check_db_test.go
+++ b/tests/e2e/pg2ch/replication/check_db_test.go
@@ -102,7 +102,7 @@ func TestOptimizeCleanup(t *testing.T) {
 	require.NoError(t, err)
 	conn, err := pgcommon.NewPgConnPool(connConfig, logger.Log)
 	require.NoError(t, err)
-
+	Target.IsDeleteable = true
 	// Start transfer
 	transfer := helpers.MakeTransfer(helpers.TransferID, &Source, &Target, TransferType)
 	err = tasks.ActivateDelivery(context.Background(), nil, cpclient.NewFakeClient(), *transfer, helpers.EmptyRegistry())

--- a/tests/e2e/pg2ch/replication/check_db_test.go
+++ b/tests/e2e/pg2ch/replication/check_db_test.go
@@ -2,7 +2,6 @@ package replication
 
 import (
 	"context"
-	"github.com/doublecloud/transfer/pkg/providers/clickhouse"
 	"os"
 	"testing"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/doublecloud/transfer/internal/logger"
 	"github.com/doublecloud/transfer/pkg/abstract"
 	cpclient "github.com/doublecloud/transfer/pkg/abstract/coordinator"
+	"github.com/doublecloud/transfer/pkg/providers/clickhouse"
 	chrecipe "github.com/doublecloud/transfer/pkg/providers/clickhouse/recipe"
 	pgcommon "github.com/doublecloud/transfer/pkg/providers/postgres"
 	"github.com/doublecloud/transfer/pkg/providers/postgres/pgrecipe"

--- a/tests/e2e/pg2ch/replication/check_db_test.go
+++ b/tests/e2e/pg2ch/replication/check_db_test.go
@@ -2,6 +2,7 @@ package replication
 
 import (
 	"context"
+	"github.com/doublecloud/transfer/pkg/providers/clickhouse"
 	"os"
 	"testing"
 	"time"
@@ -93,4 +94,69 @@ func TestSnapshotAndIncrement(t *testing.T) {
 
 	require.NoError(t, helpers.WaitEqualRowsCount(t, databaseName, "__test", helpers.GetSampleableStorageByModel(t, Source), helpers.GetSampleableStorageByModel(t, Target), 60*time.Second))
 	require.NoError(t, helpers.CompareStorages(t, Source, Target, helpers.NewCompareStorageParams().WithEqualDataTypes(pg2ch.PG2CHDataTypesComparator)))
+}
+
+func TestOptimizeCleanup(t *testing.T) {
+	// Setup same as in TestSnapshotAndIncrement
+	connConfig, err := pgcommon.MakeConnConfigFromSrc(logger.Log, &Source)
+	require.NoError(t, err)
+	conn, err := pgcommon.NewPgConnPool(connConfig, logger.Log)
+	require.NoError(t, err)
+
+	// Start transfer
+	transfer := helpers.MakeTransfer(helpers.TransferID, &Source, &Target, TransferType)
+	err = tasks.ActivateDelivery(context.Background(), nil, cpclient.NewFakeClient(), *transfer, helpers.EmptyRegistry())
+	require.NoError(t, err)
+
+	localWorker := local.NewLocalWorker(cpclient.NewFakeClient(), transfer, helpers.EmptyRegistry(), logger.Log)
+	localWorker.Start()
+	defer localWorker.Stop()
+
+	// Insert test data
+	rows, err := conn.Query(context.Background(), "INSERT INTO __test (id, val1, val2) VALUES (100, 100, 'test_cleanup')")
+	require.NoError(t, err)
+	rows.Close()
+
+	// Wait until data appears in CH
+	require.NoError(
+		t,
+		helpers.WaitEqualRowsCount(
+			t,
+			databaseName,
+			"__test",
+			helpers.GetSampleableStorageByModel(t, Source),
+			helpers.GetSampleableStorageByModel(t, Target),
+			60*time.Second,
+		),
+	)
+
+	// Delete the data
+	rows, err = conn.Query(context.Background(), "DELETE FROM __test WHERE id=100")
+	require.NoError(t, err)
+	rows.Close()
+
+	// Wait until deletion is reflected in CH
+	require.NoError(t, helpers.WaitEqualRowsCount(t, databaseName, "__test",
+		helpers.GetSampleableStorageByModel(t, Source),
+		helpers.GetSampleableStorageByModel(t, Target),
+		60*time.Second))
+
+	// Get CH connection for verification
+	chConn, err := clickhouse.MakeConnection(Target.ToStorageParams())
+	require.NoError(t, err)
+
+	// Run OPTIMIZE ... FINAL CLEANUP
+	_, err = chConn.Exec("OPTIMIZE TABLE public.__test FINAL CLEANUP")
+	require.NoError(t, err)
+
+	// Verify that rows are physically deleted
+	var count int
+	err = chConn.QueryRow("SELECT count() FROM public.__test WHERE id = 100").Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+
+	// Verify that rows don't reappear after OPTIMIZE
+	err = chConn.QueryRow("SELECT count() FROM public.__test FINAL WHERE id = 100").Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
 }


### PR DESCRIPTION
- Introduce `__data_transfer_is_deleted` generated column for tracking deletions
- Update ClickHouse destination model to support deletable flag
- Extend sink parameters interface with `IsDeleteable()` method
- Include is_deleted flag into replacing merge tree

Closes: https://github.com/doublecloud/transfer/issues/219